### PR TITLE
Auto-fix FusionPBX outbound CID defaults for new customer domains

### DIFF
--- a/app/Console/Commands/FixOutboundCid.php
+++ b/app/Console/Commands/FixOutboundCid.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\OutboundCallerIdFixer;
+use Illuminate\Console\Command;
+
+class FixOutboundCid extends Command
+{
+    protected $signature = 'pbx:fix-outbound-cid';
+
+    protected $description = 'Patch OUTBOUND_CALLER_ID dialplans and enable caller_id_in_from on gateways so extension CIDs reach upstream SIP trunks. Safe to rerun on every deploy.';
+
+    public function handle(OutboundCallerIdFixer $fixer): int
+    {
+        $result = $fixer->run();
+
+        $this->info(sprintf(
+            'dialplans patched: %d; gateways patched: %d',
+            $result['dialplans_patched'],
+            $result['gateways_patched'],
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/OutboundCallerIdFixer.php
+++ b/app/Services/OutboundCallerIdFixer.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\FusionCache;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Patches FusionPBX defaults that prevent outbound caller ID from reaching
+ * upstream SIP trunks.
+ *
+ * The stock FusionPBX OUTBOUND_CALLER_ID dialplan ends with an idempotent
+ * no-op ({@code set outbound_caller_id_number=${outbound_caller_id_number}})
+ * that never copies the extension's configured CID onto effective_caller_id
+ * or exports it as PAI. Combined with gateways shipping with
+ * {@code caller_id_in_from} unset (defaulting to false), the outbound INVITE
+ * carries only the gateway auth-user in From and the extension number in
+ * Remote-Party-ID — carriers then substitute their default trunk CLI.
+ *
+ * This runs at every deploy (via Ansible) so newly-provisioned domains get
+ * patched without a manual step.
+ */
+class OutboundCallerIdFixer
+{
+    public const BROKEN_ACTION_PATTERN =
+        '/(<condition field="\$\{outbound_caller_id_number\}" expression="\^\\\\d\{6,25\}\$" break="never">\s*\n)'
+        . '(\s*)<action application="set" data="outbound_caller_id_number=\$\{outbound_caller_id_number\}" inline="true"\/>/';
+
+    public const REPLACEMENT_FORMAT = "%s%s<action application=\"set\" data=\"effective_caller_id_number=\${outbound_caller_id_number}\" inline=\"true\"/>\n%s<action application=\"set\" data=\"effective_caller_id_name=\${outbound_caller_id_name}\" inline=\"true\"/>\n%s<action application=\"export\" data=\"sip_h_P-Asserted-Identity=<sip:\${outbound_caller_id_number}@\${domain_name}>\"/>";
+
+    /**
+     * @return array{dialplans_patched: int, gateways_patched: int}
+     */
+    public function run(): array
+    {
+        return [
+            'dialplans_patched' => $this->patchDialplans(),
+            'gateways_patched' => $this->patchGateways(),
+        ];
+    }
+
+    protected function patchDialplans(): int
+    {
+        $rows = DB::table('v_dialplans')
+            ->where('dialplan_name', 'OUTBOUND_CALLER_ID')
+            ->get(['dialplan_uuid', 'dialplan_xml']);
+
+        $patched = 0;
+
+        foreach ($rows as $row) {
+            $xml = $row->dialplan_xml;
+
+            if ($xml === null || $xml === '') {
+                continue;
+            }
+
+            // Already patched — effective_caller_id_number assignment is present.
+            if (strpos($xml, 'effective_caller_id_number=${outbound_caller_id_number}') !== false) {
+                continue;
+            }
+
+            $count = 0;
+            $newXml = preg_replace_callback(
+                self::BROKEN_ACTION_PATTERN,
+                fn ($m) => sprintf(self::REPLACEMENT_FORMAT, $m[1], $m[2], $m[2], $m[2]),
+                $xml,
+                -1,
+                $count,
+            );
+
+            if ($count > 0) {
+                DB::table('v_dialplans')
+                    ->where('dialplan_uuid', $row->dialplan_uuid)
+                    ->update([
+                        'dialplan_xml' => $newXml,
+                        'update_date' => date('Y-m-d H:i:s'),
+                    ]);
+                $patched++;
+            }
+        }
+
+        if ($patched > 0) {
+            FusionCache::clear('dialplan:public');
+        }
+
+        return $patched;
+    }
+
+    protected function patchGateways(): int
+    {
+        return DB::table('v_gateways')
+            ->where(function ($q) {
+                $q->whereNull('caller_id_in_from')->orWhere('caller_id_in_from', '');
+            })
+            ->update([
+                'caller_id_in_from' => 'true',
+                'update_date' => date('Y-m-d H:i:s'),
+            ]);
+    }
+}

--- a/database/migrations/2026_04_21_180000_fix_outbound_caller_id_dialplan_and_gateways.php
+++ b/database/migrations/2026_04_21_180000_fix_outbound_caller_id_dialplan_and_gateways.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Services\OutboundCallerIdFixer;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $result = (new OutboundCallerIdFixer())->run();
+
+        echo sprintf(
+            "[OutboundCallerIdFixer] dialplans patched: %d; gateways patched: %d\n",
+            $result['dialplans_patched'],
+            $result['gateways_patched'],
+        );
+    }
+
+    public function down(): void
+    {
+        // The forward patch converts a functionally-broken no-op into a working
+        // dialplan block; there is no meaningful rollback.
+    }
+};


### PR DESCRIPTION
## Summary
- New artisan command `pbx:fix-outbound-cid` that idempotently patches the stock FusionPBX `OUTBOUND_CALLER_ID` dialplan (replacing the no-op `set()` with proper `effective_caller_id_*` sets + PAI export) and enables `caller_id_in_from` on gateways where it's null/empty.
- Laravel migration invokes the fixer once so existing deployments pick up the patch on `php artisan migrate`.
- Companion change in `iqm-ansible` runs the command on every deploy so newly onboarded customer domains (where FusionPBX core re-creates the broken dialplan) are covered automatically.

## Why
Traced a customer call on the primary where the presented CLI was the trunk's default (`+44 20 0222 7078`) instead of the extension's configured CID. Root cause:

1. `OUTBOUND_CALLER_ID` dialplan's final set action was `outbound_caller_id_number=${outbound_caller_id_number}` — reassigns to itself, never exposes the CID to the B-leg.
2. Gateway `caller_id_in_from` shipped empty (= false), so From used only the gateway auth-user.

Confirmed end-to-end: after patch, the return leg from Magrathea arrives as `sofia/external/+441225981239@...` (CID preserved), vs. `anonymous@...` before. A real handset call now shows the correct CLI.

## Scope
- `app/Services/OutboundCallerIdFixer.php` — core patch logic (regex match + replace on dialplan XML; conservative gateway update only where the flag was unset).
- `app/Console/Commands/FixOutboundCid.php` — thin wrapper.
- `database/migrations/…fix_outbound_caller_id_dialplan_and_gateways.php` — one-shot invocation for existing installs.

Fixer is idempotent; verified against prod it returns `0 / 0` on already-patched data.

## Test plan
- [ ] CI passes
- [ ] Deploy via `ansible-playbook voxra.yml --tags fspbx` — migration + Ansible step report `0 dialplans / 0 gateways`
- [ ] Onboard a fresh customer domain, then redeploy — command reports non-zero patch count
- [ ] Outbound PSTN call from an extension with a configured CID — recipient shows that CID, not the trunk default