### PR TITLE
Add CDR API v1 (tenant-scoped + global admin)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# Voxra (fspbx fork)
+
+Fork of [nemerald-voip/fspbx](https://github.com/nemerald-voip/fspbx) — a Laravel/Vue.js frontend for FreeSWITCH PBX (originally FusionPBX).
+
+- **Origin:** `upstream` remote points to `nemerald-voip/fspbx`
+- **This fork:** `origin` at `ystwythv/fspbx`, branch `feature/elevenlabs`
+- **Branding:** Rebranded as "Voxra" (domain: `app.voxra.uk`)
+
+## Stack
+
+- **Backend:** Laravel 10, PHP 8.4, PostgreSQL 17, Redis
+- **Frontend:** Vue.js 3 with Inertia.js, Tailwind CSS, SyncFusion DataTable components, Vueform
+- **PBX:** FreeSWITCH with dialplan XML generated via Blade templates
+- **Multi-tenant:** All queries scoped by `domain_uuid`
+
+## Key patterns
+
+- UUIDs as primary keys (`TraitUuid` mixin), tables prefixed `v_`
+- String booleans (`'true'`/`'false'`) in DB columns matching FusionPBX convention
+- Routing destinations defined in `app/Services/CallRoutingOptionsService.php` — any new destination type must be added there, plus `app/helpers.php` `buildDestinationAction()`, and the relevant controllers (VirtualReceptionist, RingGroup, BusinessHours, Extensions)
+- Dialplan templates in `resources/views/layouts/xml/`
+- Vue pages in `resources/js/Pages/`, following existing patterns (e.g. `VirtualReceptionists.vue`)
+- Permissions seeded in `database/seeders/DatabaseSeeder.php`
+- Menu items stored in `v_menu_items` / `v_menu_item_groups` DB tables
+
+## ElevenLabs integration
+
+- **TTS:** `app/Services/Tts/ElevenLabsTtsService.php` — text-to-speech for greetings
+- **STT:** `app/Services/Stt/ElevenLabsSttService.php` — speech-to-text for transcription
+- **Conversational AI agents:** `app/Services/ElevenLabsConvaiService.php` — creates agents + SIP trunk phone numbers via ElevenLabs API, FreeSWITCH bridges calls to `sip.rtc.elevenlabs.io:5060`
+- API key configured via `ELEVENLABS_API_KEY` env var (needs voices_read, convai permissions)
+
+## Deployment
+
+Deployed via Ansible at `~/github/iqm-ansible/`. **Do not push directly to production — use the Ansible playbook.**
+
+### Servers
+
+| Role | Host | IP |
+|------|------|----|
+| Primary | voxra-pbx-lon1 | 172.236.17.39 |
+| Secondary | voxra-pbx-eu1 | 139.162.195.218 |
+
+Both run Ubuntu 24.04 on Linode. PostgreSQL streaming replication (primary → secondary). File sync via Syncthing.
+
+### SSH access
+
+```bash
+# Primary server
+ssh -i ~/.ssh/id_ed25519 root@172.236.17.39
+
+# Secondary server
+ssh -i ~/.ssh/id_ed25519 root@139.162.195.218
+```
+
+App root on servers: `/var/www/fspbx`
+
+Useful server-side commands:
+```bash
+cd /var/www/fspbx
+
+# Check Laravel logs
+tail -100 storage/logs/laravel.log
+
+# Laravel tinker (interactive REPL)
+php artisan tinker
+
+# Clear caches
+php artisan config:cache && php artisan route:cache
+
+# Rebuild frontend assets
+npm run build
+
+# Check FreeSWITCH status
+systemctl status freeswitch
+```
+
+### Ansible commands
+
+```bash
+cd ~/github/iqm-ansible
+
+# Full deploy (all tasks)
+ansible-playbook voxra.yml
+
+# Deploy only fspbx code updates (git pull, composer, npm build, migrations)
+ansible-playbook voxra.yml --tags fspbx
+
+# Other tags: firewall, certbot, nginx, verto, postgres, syncthing
+```
+
+### What the fspbx Ansible task does (`tasks/voxra/install-fspbx.yml`)
+
+On first run: clones repo, installs FreeSWITCH + PHP + dependencies.
+On subsequent runs: `git fetch + reset --hard` to deploy latest code, then `composer install`, `npm run build`, `php artisan migrate`, config/route cache clear.
+
+### Key Ansible vars (in `group_vars/voxra.yml`)
+
+- `fspbx_repo`: GitHub repo URL
+- `fspbx_branch`: `feature/elevenlabs`
+- `fspbx_web_root`: `/var/www/fspbx`
+- Secrets (API keys, DB passwords) in `secrets.yml` (vault-encrypted)
+
+## Development
+
+```bash
+# Install dependencies
+composer install
+npm install
+
+# Dev server
+npm run dev
+
+# Build for production
+npm run build
+
+# Run migrations
+php artisan migrate
+
+# Seed permissions and providers
+php artisan db:seed --class=DatabaseSeeder
+```

--- a/app/Console/Commands/FixOutboundCid.php
+++ b/app/Console/Commands/FixOutboundCid.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\OutboundCallerIdFixer;
+use Illuminate\Console\Command;
+
+class FixOutboundCid extends Command
+{
+    protected $signature = 'pbx:fix-outbound-cid';
+
+    protected $description = 'Patch OUTBOUND_CALLER_ID dialplans and enable caller_id_in_from on gateways so extension CIDs reach upstream SIP trunks. Safe to rerun on every deploy.';
+
+    public function handle(OutboundCallerIdFixer $fixer): int
+    {
+        $result = $fixer->run();
+
+        $this->info(sprintf(
+            'dialplans patched: %d; gateways patched: %d',
+            $result['dialplans_patched'],
+            $result['gateways_patched'],
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ResyncAiAgentElevenLabs.php
+++ b/app/Console/Commands/ResyncAiAgentElevenLabs.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\AiAgent;
+use App\Models\Domain;
+use App\Models\FusionCache;
+use App\Services\ElevenLabsConvaiService;
+use Illuminate\Console\Command;
+
+class ResyncAiAgentElevenLabs extends Command
+{
+    protected $signature = 'ai-agents:resync-elevenlabs {--uuid= : Only resync this specific AI agent uuid}';
+
+    protected $description = 'Backfill ElevenLabs SIP trunk phone numbers for existing AI agents (delete + recreate with inbound_trunk_config + reassign agent + invalidate dialplan cache).';
+
+    public function handle(ElevenLabsConvaiService $convai): int
+    {
+        $allowedAddresses = config('services.elevenlabs.sip_allowed_addresses', []);
+        if (empty($allowedAddresses)) {
+            $this->error('config services.elevenlabs.sip_allowed_addresses is empty. Set ELEVENLABS_SIP_ALLOWED_ADDRESSES in .env first.');
+            return self::FAILURE;
+        }
+
+        $query = AiAgent::query();
+        if ($uuid = $this->option('uuid')) {
+            $query->where('ai_agent_uuid', $uuid);
+        }
+
+        $agents = $query->get();
+        if ($agents->isEmpty()) {
+            $this->warn('No AI agents found.');
+            return self::SUCCESS;
+        }
+
+        $this->line("Resyncing {$agents->count()} agent(s) with allowlist: " . implode(', ', $allowedAddresses));
+
+        $failures = 0;
+        foreach ($agents as $agent) {
+            $this->line("→ {$agent->agent_extension} {$agent->agent_name} ({$agent->ai_agent_uuid})");
+
+            if (!$agent->elevenlabs_agent_id) {
+                $this->warn('  skip: no elevenlabs_agent_id');
+                continue;
+            }
+
+            try {
+                $created = $convai->replaceSipTrunkPhoneNumber(
+                    $agent->elevenlabs_phone_number_id,
+                    'Voxra Agent: ' . $agent->agent_name,
+                    (string) $agent->agent_extension,
+                    $allowedAddresses,
+                    $agent->elevenlabs_agent_id
+                );
+
+                $newId = $created['phone_number_id'] ?? null;
+                if (!$newId) {
+                    throw new \RuntimeException('No phone_number_id returned from ElevenLabs');
+                }
+
+                $agent->elevenlabs_phone_number_id = $newId;
+                $agent->update_date = date('Y-m-d H:i:s');
+                $agent->save();
+
+                // Invalidate the dialplan cache for this agent's domain so the
+                // bridge action picks up the regenerated XML on the next call.
+                $domain = Domain::where('domain_uuid', $agent->domain_uuid)->first();
+                if ($domain) {
+                    FusionCache::clear('dialplan.' . $domain->domain_name);
+                }
+
+                $this->info("  ok: phone_number_id={$newId}");
+            } catch (\Throwable $e) {
+                $failures++;
+                $this->error('  fail: ' . $e->getMessage());
+            }
+        }
+
+        if ($failures > 0) {
+            $this->error("{$failures} agent(s) failed.");
+            return self::FAILURE;
+        }
+
+        $this->info('Done.');
+        return self::SUCCESS;
+    }
+}

--- a/app/Data/Api/V1/AiAgentData.php
+++ b/app/Data/Api/V1/AiAgentData.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Data\Api\V1;
+
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Optional;
+
+class AiAgentData extends Data
+{
+    public function __construct(
+        public string $ai_agent_uuid,
+        public string $object,
+        public string $domain_uuid,
+
+        public string $agent_name,
+        public string $agent_extension,
+
+        public bool|Optional|null $agent_enabled = new Optional(),
+
+        public ?string $description = null,
+
+        public string|Optional|null $voice_id = new Optional(),
+        public string|Optional|null $language = new Optional(),
+        public string|Optional|null $first_message = new Optional(),
+        public string|Optional|null $system_prompt = new Optional(),
+
+        public string|Optional|null $elevenlabs_agent_id = new Optional(),
+        public string|Optional|null $elevenlabs_phone_number_id = new Optional(),
+    ) {}
+}

--- a/app/Data/Api/V1/Cdr/CdrCallData.php
+++ b/app/Data/Api/V1/Cdr/CdrCallData.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Data\Api\V1\Cdr;
+
+use Spatie\LaravelData\Data;
+
+class CdrCallData extends Data
+{
+    public function __construct(
+        public string $xml_cdr_uuid,
+        public string $object,
+        public string $domain_uuid,
+        public ?string $direction,
+        public string $status,
+        public ?string $caller_id_name,
+        public ?string $caller_id_number,
+        public ?string $destination_number,
+        public ?string $caller_destination,
+        public ?string $start_time,
+        public ?string $answer_time,
+        public ?string $end_time,
+        public ?int $duration,
+        public ?int $billsec,
+        public ?string $hangup_cause,
+        public ?int $hangup_cause_q850,
+        public ?string $sip_hangup_disposition,
+        public ?string $extension_uuid,
+        public ?string $queue_uuid,
+        public ?float $mos_inbound,
+        public ?float $cost,
+        public ?string $cost_currency,
+        public bool $has_recording,
+        public ?string $recording_url,
+        public ?string $sip_call_id,
+    ) {}
+}

--- a/app/Data/Api/V1/Cdr/CdrCallDetailData.php
+++ b/app/Data/Api/V1/Cdr/CdrCallDetailData.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Data\Api\V1\Cdr;
+
+use Spatie\LaravelData\Data;
+
+class CdrCallDetailData extends Data
+{
+    /**
+     * @param array<string, mixed>|null $call_flow
+     * @param array<int, array<string, mixed>> $related_legs
+     */
+    public function __construct(
+        public string $xml_cdr_uuid,
+        public string $object,
+        public string $domain_uuid,
+        public ?string $direction,
+        public string $status,
+        public ?string $caller_id_name,
+        public ?string $caller_id_number,
+        public ?string $destination_number,
+        public ?string $caller_destination,
+        public ?string $start_time,
+        public ?string $answer_time,
+        public ?string $end_time,
+        public ?int $duration,
+        public ?int $billsec,
+        public ?string $hangup_cause,
+        public ?int $hangup_cause_q850,
+        public ?string $sip_hangup_disposition,
+        public ?string $extension_uuid,
+        public ?string $queue_uuid,
+        public ?float $mos_inbound,
+        public ?float $mos_outbound,
+        public ?float $jitter_ms,
+        public ?float $packet_loss,
+        public ?float $cost,
+        public ?string $cost_currency,
+        public bool $has_recording,
+        public ?string $recording_url,
+        public ?string $sip_call_id,
+        public ?int $pdd_ms,
+        public ?string $read_codec,
+        public ?int $read_rate,
+        public ?string $write_codec,
+        public ?int $write_rate,
+        public ?string $remote_media_ip,
+        public ?string $network_addr,
+        public ?string $accountcode,
+        public ?array $call_flow,
+        public array $related_legs,
+    ) {}
+}

--- a/app/Data/Api/V1/Cdr/CdrFilterData.php
+++ b/app/Data/Api/V1/Cdr/CdrFilterData.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Data\Api\V1\Cdr;
+
+use App\Enums\Cdr\CallDirection;
+use App\Enums\Cdr\CallStatus;
+use Spatie\LaravelData\Data;
+
+class CdrFilterData extends Data
+{
+    public function __construct(
+        public int $dateFromEpoch,
+        public int $dateToEpoch,
+        public ?CallDirection $direction = null,
+        public ?CallStatus $status = null,
+        public ?string $hangupCause = null,
+        public ?string $extensionUuid = null,
+        public ?string $queueUuid = null,
+        public ?string $callerNumber = null,
+        public ?string $destinationNumber = null,
+        public ?int $minDuration = null,
+        public ?int $maxDuration = null,
+        public ?float $minMos = null,
+        public ?bool $hasRecording = null,
+    ) {}
+}

--- a/app/Data/Api/V1/Cdr/CdrListResponseData.php
+++ b/app/Data/Api/V1/Cdr/CdrListResponseData.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Data\Api\V1\Cdr;
+
+use Spatie\LaravelData\Data;
+
+class CdrListResponseData extends Data
+{
+    /**
+     * @param array<int, CdrCallData> $data
+     */
+    public function __construct(
+        public string $object,
+        public string $url,
+        public bool $has_more,
+        public array $data,
+    ) {}
+}

--- a/app/Data/Api/V1/UserData.php
+++ b/app/Data/Api/V1/UserData.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Data\Api\V1;
+
+use App\Models\User;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Optional;
+
+class UserData extends Data
+{
+    public function __construct(
+        public string $user_uuid,
+        public string $object,
+        public string $domain_uuid,
+        public string $username,
+        public ?string $user_email,
+        public ?string $first_name,
+        public ?string $last_name,
+        public ?string $name_formatted,
+        public bool $user_enabled,
+        public bool $is_domain_admin,
+        public string|Optional|null $language = new Optional(),
+        public string|Optional|null $time_zone = new Optional(),
+        public ?string $created_at = null,
+    ) {}
+
+    public static function fromModel(User $user): self
+    {
+        $isAdmin = false;
+        if ($user->relationLoaded('user_groups') || $user->user_groups) {
+            $isAdmin = $user->user_groups->contains(function ($ug) {
+                return strtolower((string) $ug->group_name) === 'admin'
+                    || strtolower((string) $ug->group_name) === 'superadmin';
+            });
+        }
+
+        return new self(
+            user_uuid: (string) $user->user_uuid,
+            object: 'user',
+            domain_uuid: (string) $user->domain_uuid,
+            username: (string) $user->username,
+            user_email: $user->user_email,
+            first_name: $user->first_name ?: null,
+            last_name: $user->last_name ?: null,
+            name_formatted: $user->name_formatted,
+            user_enabled: self::textBool($user->user_enabled),
+            is_domain_admin: $isAdmin,
+            language: $user->language,
+            time_zone: $user->time_zone,
+            created_at: $user->add_date ? (string) $user->add_date : null,
+        );
+    }
+
+    private static function textBool($value): bool
+    {
+        if (is_bool($value)) return $value;
+        if ($value === null || $value === '') return false;
+        $v = strtolower(trim((string) $value));
+        return in_array($v, ['true', 't', '1', 'yes', 'y', 'on'], true);
+    }
+}

--- a/app/Enums/Cdr/CallDirection.php
+++ b/app/Enums/Cdr/CallDirection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums\Cdr;
+
+enum CallDirection: string
+{
+    case Inbound = 'inbound';
+    case Outbound = 'outbound';
+    case Local = 'local';
+
+    public static function tryFromLoose(?string $value): ?self
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        return self::tryFrom(strtolower($value));
+    }
+}

--- a/app/Enums/Cdr/CallStatus.php
+++ b/app/Enums/Cdr/CallStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums\Cdr;
+
+enum CallStatus: string
+{
+    case Answered = 'answered';
+    case Missed = 'missed';
+    case Voicemail = 'voicemail';
+    case Abandoned = 'abandoned';
+    case Busy = 'busy';
+    case NoAnswer = 'no_answer';
+    case Failed = 'failed';
+
+    public static function tryFromLoose(?string $value): ?self
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $normalized = str_replace([' ', '-'], '_', strtolower($value));
+        return self::tryFrom($normalized);
+    }
+}

--- a/app/Http/Controllers/AiAgentController.php
+++ b/app/Http/Controllers/AiAgentController.php
@@ -4,11 +4,13 @@ namespace App\Http\Controllers;
 
 use Inertia\Inertia;
 use App\Models\AiAgent;
+use App\Models\AiAgentKbDocument;
 use App\Models\Dialplans;
 use App\Models\FusionCache;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\AllowedFilter;
 use App\Services\CallRoutingOptionsService;
@@ -16,6 +18,7 @@ use App\Services\ElevenLabsConvaiService;
 use App\Services\Tts\ElevenLabsTtsService;
 use App\Http\Requests\StoreAiAgentRequest;
 use App\Http\Requests\UpdateAiAgentRequest;
+use App\Http\Requests\StoreAiAgentKbDocumentRequest;
 use App\Traits\ChecksLimits;
 
 class AiAgentController extends Controller
@@ -247,6 +250,22 @@ class AiAgentController extends Controller
             }
 
             foreach ($items as $item) {
+                // Clean up KB documents (ElevenLabs + local files + DB rows)
+                $kbDocs = AiAgentKbDocument::where('ai_agent_uuid', $item->ai_agent_uuid)->get();
+                foreach ($kbDocs as $kbDoc) {
+                    if ($convaiService && $kbDoc->elevenlabs_documentation_id) {
+                        try {
+                            $convaiService->deleteKbDocument($kbDoc->elevenlabs_documentation_id);
+                        } catch (\Exception $e) {
+                            logger('ElevenLabs KB cleanup warning: ' . $e->getMessage());
+                        }
+                    }
+                    if ($kbDoc->file_path && Storage::disk('local')->exists($kbDoc->file_path)) {
+                        Storage::disk('local')->delete($kbDoc->file_path);
+                    }
+                    $kbDoc->delete();
+                }
+
                 // Clean up ElevenLabs resources
                 if ($convaiService) {
                     try {
@@ -353,6 +372,8 @@ class AiAgentController extends Controller
                 'store_route' => route('ai-agents.store'),
             ];
 
+            $kbDocuments = [];
+
             $routingOptionsService = new CallRoutingOptionsService;
             $routingTypes = $routingOptionsService->routingTypes;
 
@@ -371,8 +392,30 @@ class AiAgentController extends Controller
                     ->firstOrFail();
 
                 $routes = array_merge($routes, [
-                    'update_route' => route('ai-agents.update', $agent),
+                    'update_route'     => route('ai-agents.update', $agent),
+                    'kb_store_route'   => route('ai-agents.kb.store', ['ai_agent' => $agent->ai_agent_uuid]),
                 ]);
+
+                $kbDocuments = $agent->kbDocuments()
+                    ->orderBy('insert_date', 'desc')
+                    ->get([
+                        'kb_document_uuid',
+                        'document_type',
+                        'name',
+                        'url',
+                        'file_mime_type',
+                        'file_size',
+                        'sync_status',
+                        'sync_error',
+                    ])
+                    ->map(function ($doc) {
+                        return array_merge($doc->toArray(), [
+                            'delete_route' => route('ai-agents.kb.delete', [
+                                'ai_agent'    => $doc->ai_agent_uuid,
+                                'kb_document' => $doc->kb_document_uuid,
+                            ]),
+                        ]);
+                    });
             } else {
                 if ($resp = $this->enforceLimit('ai_agents', AiAgent::class, 'domain_uuid', 'ai_agent_limit_error')) {
                     return $resp;
@@ -419,6 +462,7 @@ class AiAgentController extends Controller
                 'routing_types' => $routingTypes,
                 'voices' => $voices,
                 'languages' => $languages,
+                'kb_documents' => $kbDocuments,
             ]);
         } catch (\Throwable $e) {
             logger('Error: ' . $e->getMessage() . " at " . $e->getFile() . ":" . $e->getLine());
@@ -438,6 +482,154 @@ class AiAgentController extends Controller
             'ai_agent_destroy' => userCheckPermission('ai_agent_delete'),
             'is_superadmin' => isSuperAdmin(),
         ];
+    }
+
+    public function storeKbDocument(StoreAiAgentKbDocumentRequest $request, string $aiAgentUuid)
+    {
+        if (!userCheckPermission('ai_agent_edit')) {
+            return response()->json(['errors' => ['server' => ['Permission denied.']]], 403);
+        }
+
+        $inputs = $request->validated();
+
+        try {
+            $agent = AiAgent::where('ai_agent_uuid', $aiAgentUuid)
+                ->where('domain_uuid', session('domain_uuid'))
+                ->firstOrFail();
+
+            if (!$agent->elevenlabs_agent_id) {
+                return response()->json([
+                    'errors' => ['server' => ['This agent is not linked to ElevenLabs.']]
+                ], 422);
+            }
+
+            $convaiService = app(ElevenLabsConvaiService::class);
+
+            $kbDoc = new AiAgentKbDocument();
+            $kbDoc->kb_document_uuid = (string) Str::uuid();
+            $kbDoc->ai_agent_uuid    = $agent->ai_agent_uuid;
+            $kbDoc->domain_uuid      = $agent->domain_uuid;
+            $kbDoc->document_type    = $inputs['document_type'];
+            $kbDoc->name             = $inputs['name'];
+            $kbDoc->insert_date      = date('Y-m-d H:i:s');
+            $kbDoc->insert_user      = session('user_uuid');
+
+            $elevenlabsResponse = null;
+
+            if ($inputs['document_type'] === 'file') {
+                $uploaded = $request->file('file');
+                $relativePath = 'ai_agent_kb/' . $agent->domain_uuid . '/' . $kbDoc->kb_document_uuid . '/' . $uploaded->getClientOriginalName();
+                Storage::disk('local')->put($relativePath, file_get_contents($uploaded->getRealPath()));
+
+                $kbDoc->file_path      = $relativePath;
+                $kbDoc->file_mime_type = $uploaded->getClientMimeType();
+                $kbDoc->file_size      = $uploaded->getSize();
+
+                $elevenlabsResponse = $convaiService->uploadKbFile(
+                    Storage::disk('local')->path($relativePath),
+                    $inputs['name']
+                );
+            } elseif ($inputs['document_type'] === 'url') {
+                $kbDoc->url = $inputs['url'];
+                $elevenlabsResponse = $convaiService->addKbUrl($inputs['url'], $inputs['name']);
+            } else { // text
+                $kbDoc->text_content = $inputs['text'];
+                $elevenlabsResponse = $convaiService->addKbText($inputs['text'], $inputs['name']);
+            }
+
+            $kbDoc->elevenlabs_documentation_id = $elevenlabsResponse['id']
+                ?? $elevenlabsResponse['documentation_id']
+                ?? null;
+            $kbDoc->sync_status = $kbDoc->elevenlabs_documentation_id ? 'synced' : 'failed';
+            $kbDoc->save();
+
+            // Re-PATCH the agent with the full KB array
+            $this->syncAgentKbList($agent, $convaiService);
+
+            return response()->json([
+                'kb_document' => array_merge($kbDoc->toArray(), [
+                    'delete_route' => route('ai-agents.kb.delete', [
+                        'ai_agent'    => $agent->ai_agent_uuid,
+                        'kb_document' => $kbDoc->kb_document_uuid,
+                    ]),
+                ]),
+                'messages' => ['success' => ['Knowledge base document added.']],
+            ], 201);
+        } catch (\Exception $e) {
+            logger($e->getMessage() . " at " . $e->getFile() . ":" . $e->getLine());
+            return response()->json([
+                'errors' => ['server' => ['Failed to add knowledge base document. ' . $e->getMessage()]]
+            ], 500);
+        }
+    }
+
+    public function deleteKbDocument(string $aiAgentUuid, string $kbDocumentUuid)
+    {
+        if (!userCheckPermission('ai_agent_edit')) {
+            return response()->json(['errors' => ['server' => ['Permission denied.']]], 403);
+        }
+
+        try {
+            $agent = AiAgent::where('ai_agent_uuid', $aiAgentUuid)
+                ->where('domain_uuid', session('domain_uuid'))
+                ->firstOrFail();
+
+            $kbDoc = AiAgentKbDocument::where('kb_document_uuid', $kbDocumentUuid)
+                ->where('ai_agent_uuid', $agent->ai_agent_uuid)
+                ->firstOrFail();
+
+            $convaiService = app(ElevenLabsConvaiService::class);
+
+            if ($kbDoc->elevenlabs_documentation_id) {
+                try {
+                    $convaiService->deleteKbDocument($kbDoc->elevenlabs_documentation_id);
+                } catch (\Exception $e) {
+                    logger('ElevenLabs KB delete warning: ' . $e->getMessage());
+                }
+            }
+
+            if ($kbDoc->file_path && Storage::disk('local')->exists($kbDoc->file_path)) {
+                Storage::disk('local')->delete($kbDoc->file_path);
+            }
+
+            $kbDoc->delete();
+
+            // Re-PATCH the agent with the remaining KB array
+            $this->syncAgentKbList($agent, $convaiService);
+
+            return response()->json([
+                'messages' => ['success' => ['Knowledge base document removed.']],
+            ], 200);
+        } catch (\Exception $e) {
+            logger($e->getMessage() . " at " . $e->getFile() . ":" . $e->getLine());
+            return response()->json([
+                'errors' => ['server' => ['Failed to remove knowledge base document.']]
+            ], 500);
+        }
+    }
+
+    private function syncAgentKbList(AiAgent $agent, ElevenLabsConvaiService $convaiService): void
+    {
+        if (!$agent->elevenlabs_agent_id) {
+            return;
+        }
+
+        $docs = AiAgentKbDocument::where('ai_agent_uuid', $agent->ai_agent_uuid)
+            ->where('sync_status', 'synced')
+            ->whereNotNull('elevenlabs_documentation_id')
+            ->get(['document_type', 'elevenlabs_documentation_id', 'name'])
+            ->map(fn($d) => [
+                'type' => $d->document_type,
+                'id'   => $d->elevenlabs_documentation_id,
+                'name' => $d->name,
+            ])
+            ->toArray();
+
+        try {
+            $convaiService->setAgentKnowledgeBase($agent->elevenlabs_agent_id, $docs);
+        } catch (\Exception $e) {
+            logger('ElevenLabs setAgentKnowledgeBase warning: ' . $e->getMessage());
+        }
     }
 
     public function selectAll()

--- a/app/Http/Controllers/AiAgentController.php
+++ b/app/Http/Controllers/AiAgentController.php
@@ -401,6 +401,7 @@ class AiAgentController extends Controller
                     ->orderBy('insert_date', 'desc')
                     ->get([
                         'kb_document_uuid',
+                        'ai_agent_uuid',
                         'document_type',
                         'name',
                         'url',

--- a/app/Http/Controllers/AiAgentController.php
+++ b/app/Http/Controllers/AiAgentController.php
@@ -116,7 +116,8 @@ class AiAgentController extends Controller
                 try {
                     $phoneResponse = $convaiService->createSipTrunkPhoneNumber(
                         'Voxra Agent: ' . $inputs['agent_name'],
-                        '+1' . $inputs['agent_extension'],
+                        $inputs['agent_extension'],
+                        config('services.elevenlabs.sip_allowed_addresses', []),
                     );
                     $elevenlabsPhoneNumberId = $phoneResponse['phone_number_id'] ?? null;
 

--- a/app/Http/Controllers/Api/V1/Admin/ApiTokenController.php
+++ b/app/Http/Controllers/Api/V1/Admin/ApiTokenController.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use App\Models\Domain;
+use App\Models\Sanctum\PersonalAccessToken;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class ApiTokenController extends Controller
+{
+    /**
+     * List API tokens.
+     *
+     * @group Admin API Tokens
+     * @authenticated
+     */
+    public function index(Request $request)
+    {
+        $this->assertUser($request);
+
+        $limit = max(1, min(100, (int) $request->query('limit', 25)));
+        $startingAfter = trim((string) $request->query('starting_after', ''));
+
+        $query = PersonalAccessToken::query()->orderBy('id');
+        if ($startingAfter !== '') {
+            $query->where('id', '>', $startingAfter);
+        }
+
+        $rows = $query->limit($limit + 1)->get();
+        $hasMore = $rows->count() > $limit;
+        $rows = $rows->take($limit);
+
+        return response()->json([
+            'object' => 'list',
+            'url' => '/api/v1/admin/api-tokens',
+            'has_more' => $hasMore,
+            'data' => $rows->map(fn ($t) => $this->summarize($t))->all(),
+        ], 200);
+    }
+
+    /**
+     * Create an API token.
+     *
+     * Body:
+     * - name (required)
+     * - type: "global" or "tenant" (required)
+     * - domain_uuid: required when type="tenant", forbidden when type="global"
+     * - expires_at: optional ISO 8601
+     * - abilities: optional string[]
+     *
+     * The plain-text token is returned once in `token`; it is unrecoverable
+     * afterwards.
+     *
+     * @group Admin API Tokens
+     * @authenticated
+     */
+    public function store(Request $request)
+    {
+        $user = $this->assertUser($request);
+
+        $name = trim((string) $request->input('name', ''));
+        $type = strtolower(trim((string) $request->input('type', '')));
+        $domainUuid = trim((string) $request->input('domain_uuid', ''));
+        $expiresAtRaw = trim((string) $request->input('expires_at', ''));
+        $abilities = $request->input('abilities');
+
+        if ($name === '') {
+            throw new ApiException(422, 'invalid_request_error', 'name is required.', 'parameter_missing', 'name');
+        }
+
+        if (! in_array($type, ['global', 'tenant'], true)) {
+            throw new ApiException(422, 'invalid_request_error', 'type must be "global" or "tenant".', 'invalid_request', 'type');
+        }
+
+        if ($type === 'tenant') {
+            if ($domainUuid === '' || ! preg_match('/^[0-9a-fA-F-]{36}$/', $domainUuid)) {
+                throw new ApiException(422, 'invalid_request_error', 'domain_uuid is required for tenant tokens.', 'parameter_missing', 'domain_uuid');
+            }
+            if (! Domain::query()->where('domain_uuid', $domainUuid)->exists()) {
+                throw new ApiException(404, 'invalid_request_error', 'Domain not found.', 'resource_missing', 'domain_uuid');
+            }
+        } elseif ($domainUuid !== '') {
+            throw new ApiException(422, 'invalid_request_error', 'domain_uuid must not be set for global tokens.', 'invalid_request', 'domain_uuid');
+        }
+
+        $abilitiesArray = $this->normaliseAbilities($abilities, $type);
+
+        $expiresAt = null;
+        if ($expiresAtRaw !== '') {
+            try {
+                $expiresAt = Carbon::parse($expiresAtRaw);
+            } catch (\Throwable $e) {
+                throw new ApiException(422, 'invalid_request_error', 'Invalid expires_at.', 'invalid_request', 'expires_at');
+            }
+            if ($expiresAt->isPast()) {
+                throw new ApiException(422, 'invalid_request_error', 'expires_at must be in the future.', 'invalid_request', 'expires_at');
+            }
+        }
+
+        $newToken = $user->createToken($name, $abilitiesArray, $expiresAt);
+
+        $token = $newToken->accessToken;
+        if ($type === 'tenant') {
+            $token->forceFill(['domain_uuid' => $domainUuid])->save();
+        }
+
+        return response()->json([
+            'object' => 'api_token',
+            'id' => (string) $token->id,
+            'name' => $token->name,
+            'type' => $type,
+            'domain_uuid' => $type === 'tenant' ? $domainUuid : null,
+            'abilities' => $abilitiesArray,
+            'expires_at' => $expiresAt?->toIso8601ZuluString(),
+            'created_at' => $token->created_at?->toIso8601ZuluString(),
+            'token' => $newToken->plainTextToken,
+        ], 201);
+    }
+
+    /**
+     * Revoke an API token.
+     *
+     * @group Admin API Tokens
+     * @authenticated
+     */
+    public function destroy(Request $request, string $token_id)
+    {
+        $this->assertUser($request);
+
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $token_id)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid token id.', 'invalid_request', 'token_id');
+        }
+
+        $token = PersonalAccessToken::query()->where('id', $token_id)->first();
+        if (! $token) {
+            throw new ApiException(404, 'invalid_request_error', 'Token not found.', 'resource_missing', 'token_id');
+        }
+
+        $token->delete();
+
+        return response()->json([
+            'object' => 'api_token',
+            'id' => $token_id,
+            'deleted' => true,
+        ], 200);
+    }
+
+    private function assertUser(Request $request)
+    {
+        $user = $request->user();
+        if (! $user) {
+            throw new ApiException(401, 'authentication_error', 'Unauthenticated.', 'unauthenticated');
+        }
+        return $user;
+    }
+
+    private function normaliseAbilities($abilities, string $type): array
+    {
+        $default = $type === 'global' ? ['cdr:read', 'cdr:all-domains'] : ['cdr:read'];
+
+        if ($abilities === null || $abilities === '' || $abilities === []) {
+            return $default;
+        }
+
+        if (is_string($abilities)) {
+            $abilities = preg_split('/\s*,\s*/', $abilities, -1, PREG_SPLIT_NO_EMPTY);
+        }
+
+        if (! is_array($abilities)) {
+            throw new ApiException(422, 'invalid_request_error', 'abilities must be an array of strings.', 'invalid_request', 'abilities');
+        }
+
+        $clean = array_values(array_unique(array_filter(array_map(fn ($a) => trim((string) $a), $abilities))));
+        return $clean === [] ? $default : $clean;
+    }
+
+    private function summarize(PersonalAccessToken $t): array
+    {
+        $type = $t->domain_uuid ? 'tenant' : 'global';
+        return [
+            'object' => 'api_token',
+            'id' => (string) $t->id,
+            'name' => $t->name,
+            'type' => $type,
+            'domain_uuid' => $t->domain_uuid,
+            'abilities' => $t->abilities ?? [],
+            'last_used_at' => $t->last_used_at?->toIso8601ZuluString(),
+            'expires_at' => $t->expires_at?->toIso8601ZuluString(),
+            'created_at' => $t->created_at?->toIso8601ZuluString(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/AiAgentController.php
+++ b/app/Http/Controllers/Api/V1/AiAgentController.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Data\Api\V1\AiAgentData;
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use App\Models\AiAgent;
+use App\Models\Domain;
+use Illuminate\Http\Request;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class AiAgentController extends Controller
+{
+    /**
+     * List AI agents
+     *
+     * Returns AI agents for the specified domain the caller is allowed to access.
+     *
+     * Access rules:
+     * - Caller must have access to the target domain (domain scope).
+     * - Caller must have the `ai_agent_view` permission.
+     *
+     * Pagination (cursor-based):
+     * - Both `limit` and `starting_after` are optional.
+     * - If `limit` is not provided, it defaults to 50.
+     * - If `starting_after` is not provided, results start from the beginning.
+     * - If `has_more` is true, request the next page by passing `starting_after`
+     *   equal to the last item's `ai_agent_uuid` from the previous response.
+     *
+     * @group AI Agents
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     * @queryParam limit integer Optional. Number of results to return (min 1, max 100). Defaults to 50. Example: 50
+     * @queryParam starting_after string Optional. Return results after this AI agent UUID (cursor). Example: c0ec8113-aa15-40ac-8437-47185dd9dcf4
+     *
+     * @response 200 scenario="Success" {
+     *   "object": "list",
+     *   "url": "/api/v1/domains/4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b/ai-agents",
+     *   "has_more": false,
+     *   "data": [
+     *     {
+     *       "ai_agent_uuid": "c0ec8113-aa15-40ac-8437-47185dd9dcf4",
+     *       "object": "ai_agent",
+     *       "domain_uuid": "4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b",
+     *       "agent_name": "Sales Receptionist",
+     *       "agent_extension": "9250",
+     *       "agent_enabled": true,
+     *       "description": "Handles inbound sales enquiries"
+     *     }
+     *   ]
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid starting_after UUID" {"error":{"type":"invalid_request_error","message":"Invalid starting_after UUID.","code":"invalid_request","param":"starting_after"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     */
+    public function index(Request $request, string $domain_uuid)
+    {
+        $user = $request->user();
+        if (! $user) {
+            throw new ApiException(401, 'authentication_error', 'Unauthenticated.', 'unauthenticated');
+        }
+
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $domain_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid domain UUID.', 'invalid_request', 'domain_uuid');
+        }
+
+        $domainExists = Domain::query()->where('domain_uuid', $domain_uuid)->exists();
+        if (! $domainExists) {
+            throw new ApiException(404, 'invalid_request_error', 'Domain not found.', 'resource_missing', 'domain_uuid');
+        }
+
+        $limit = (int) $request->input('limit', 50);
+        $limit = max(1, min(100, $limit));
+
+        $startingAfter = (string) $request->input('starting_after', '');
+
+        $textBool = static function ($value): ?bool {
+            // v_ai_agents stores booleans as text ('true'/'false')
+            if ($value === null || $value === '') return null;
+            if (is_bool($value)) return $value;
+            if (is_numeric($value)) return ((int) $value) === 1;
+            $v = strtolower(trim((string) $value));
+            if (in_array($v, ['true', 't', '1', 'yes', 'y', 'on'], true)) return true;
+            if (in_array($v, ['false', 'f', '0', 'no', 'n', 'off'], true)) return false;
+            return null;
+        };
+
+        $query = QueryBuilder::for(AiAgent::class)
+            ->where('domain_uuid', $domain_uuid)
+            ->defaultSort('ai_agent_uuid')
+            ->reorder('ai_agent_uuid')
+            ->limit($limit + 1)
+            ->select([
+                'ai_agent_uuid',
+                'domain_uuid',
+                'agent_name',
+                'agent_extension',
+                'agent_enabled',
+                'description',
+            ]);
+
+        if ($startingAfter !== '') {
+            if (! preg_match('/^[0-9a-fA-F-]{36}$/', $startingAfter)) {
+                throw new ApiException(400, 'invalid_request_error', 'Invalid starting_after UUID.', 'invalid_request', 'starting_after');
+            }
+            $query->where('ai_agent_uuid', '>', $startingAfter);
+        }
+
+        $rows = $query->get();
+        $hasMore = $rows->count() > $limit;
+        $rows = $rows->take($limit);
+
+        $data = $rows->map(function ($a) use ($textBool) {
+            return new AiAgentData(
+                ai_agent_uuid: (string) $a->ai_agent_uuid,
+                object: 'ai_agent',
+                domain_uuid: (string) $a->domain_uuid,
+
+                agent_name: (string) $a->agent_name,
+                agent_extension: (string) $a->agent_extension,
+
+                agent_enabled: $textBool($a->agent_enabled),
+
+                description: $a->description,
+            );
+        });
+
+        return response()->json([
+            'object'   => 'list',
+            'url'      => "/api/v1/domains/{$domain_uuid}/ai-agents",
+            'has_more' => $hasMore,
+            'data'     => $data,
+        ], 200);
+    }
+
+    /**
+     * Retrieve an AI agent
+     *
+     * Returns a single AI agent for the specified domain the caller is allowed to access.
+     *
+     * Access rules:
+     * - Caller must have access to the target domain (domain scope).
+     * - Caller must have the `ai_agent_view` permission.
+     *
+     * @group AI Agents
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 7d58342b-2b29-4dcf-92d6-e9a9e002a4e5
+     * @urlParam ai_agent_uuid string required The AI agent UUID. Example: 40aec3e8-a572-40da-954b-ddf6a8a65324
+     *
+     * @response 200 scenario="Success" {
+     *   "ai_agent_uuid": "40aec3e8-a572-40da-954b-ddf6a8a65324",
+     *   "object": "ai_agent",
+     *   "domain_uuid": "7d58342b-2b29-4dcf-92d6-e9a9e002a4e5",
+     *   "agent_name": "Sales Receptionist",
+     *   "agent_extension": "9250",
+     *   "agent_enabled": true,
+     *   "description": "Handles inbound sales enquiries",
+     *   "voice_id": "21m00Tcm4TlvDq8ikWAM",
+     *   "language": "en",
+     *   "first_message": "Hello, how can I help?",
+     *   "system_prompt": "You are a helpful receptionist...",
+     *   "elevenlabs_agent_id": "abc123",
+     *   "elevenlabs_phone_number_id": "pn_xyz"
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid AI agent UUID" {"error":{"type":"invalid_request_error","message":"Invalid AI agent UUID.","code":"invalid_request","param":"ai_agent_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     * @response 404 scenario="AI agent not found" {"error":{"type":"invalid_request_error","message":"AI agent not found.","code":"resource_missing","param":"ai_agent_uuid"}}
+     */
+    public function show(Request $request, string $domain_uuid, string $ai_agent_uuid)
+    {
+        $user = $request->user();
+        if (! $user) {
+            throw new ApiException(401, 'authentication_error', 'Unauthenticated.', 'unauthenticated');
+        }
+
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $domain_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid domain UUID.', 'invalid_request', 'domain_uuid');
+        }
+
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $ai_agent_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid AI agent UUID.', 'invalid_request', 'ai_agent_uuid');
+        }
+
+        $domainExists = Domain::query()->where('domain_uuid', $domain_uuid)->exists();
+        if (! $domainExists) {
+            throw new ApiException(404, 'invalid_request_error', 'Domain not found.', 'resource_missing', 'domain_uuid');
+        }
+
+        $textBool = static function ($value): ?bool {
+            if ($value === null || $value === '') return null;
+            if (is_bool($value)) return $value;
+            if (is_numeric($value)) return ((int) $value) === 1;
+            $v = strtolower(trim((string) $value));
+            if (in_array($v, ['true', 't', '1', 'yes', 'y', 'on'], true)) return true;
+            if (in_array($v, ['false', 'f', '0', 'no', 'n', 'off'], true)) return false;
+            return null;
+        };
+
+        $agent = AiAgent::query()
+            ->where('domain_uuid', $domain_uuid)
+            ->where('ai_agent_uuid', $ai_agent_uuid)
+            ->select([
+                'ai_agent_uuid',
+                'domain_uuid',
+                'agent_name',
+                'agent_extension',
+                'agent_enabled',
+                'description',
+                'voice_id',
+                'language',
+                'first_message',
+                'system_prompt',
+                'elevenlabs_agent_id',
+                'elevenlabs_phone_number_id',
+            ])
+            ->first();
+
+        if (! $agent) {
+            throw new ApiException(404, 'invalid_request_error', 'AI agent not found.', 'resource_missing', 'ai_agent_uuid');
+        }
+
+        $payload = new AiAgentData(
+            ai_agent_uuid: (string) $agent->ai_agent_uuid,
+            object: 'ai_agent',
+            domain_uuid: (string) $agent->domain_uuid,
+
+            agent_name: (string) $agent->agent_name,
+            agent_extension: (string) $agent->agent_extension,
+
+            agent_enabled: $textBool($agent->agent_enabled),
+
+            description: $agent->description,
+
+            voice_id: $agent->voice_id,
+            language: $agent->language,
+            first_message: $agent->first_message,
+            system_prompt: $agent->system_prompt,
+
+            elevenlabs_agent_id: $agent->elevenlabs_agent_id,
+            elevenlabs_phone_number_id: $agent->elevenlabs_phone_number_id,
+        );
+
+        return response()->json($payload->toArray(), 200);
+    }
+}

--- a/app/Http/Controllers/Api/V1/CdrCallController.php
+++ b/app/Http/Controllers/Api/V1/CdrCallController.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Data\Api\V1\Cdr\CdrCallData;
+use App\Data\Api\V1\Cdr\CdrCallDetailData;
+use App\Data\Api\V1\Cdr\CdrListResponseData;
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use App\Models\CDR;
+use App\Services\CallRecordingUrlService;
+use App\Services\Cdr\CallStatusResolver;
+use App\Services\Cdr\CdrApiFilterParser;
+use App\Services\Cdr\CdrQueryService;
+use Illuminate\Http\Request;
+
+class CdrCallController extends Controller
+{
+    public function __construct(
+        protected CdrQueryService $queries,
+        protected CallStatusResolver $statusResolver,
+        protected CallRecordingUrlService $recordingUrls,
+        protected CdrApiFilterParser $filterParser,
+    ) {}
+
+    /**
+     * List call detail records
+     *
+     * Returns CDRs for the specified domain within a bounded date window.
+     *
+     * Access rules:
+     * - Tenant token: must match the domain_uuid in the URL.
+     * - Global token: may access any domain.
+     * - Caller must have the `cdr_api_read` permission.
+     *
+     * Window rules:
+     * - `date_from` and `date_to` are required, ISO 8601 UTC.
+     * - The window may not exceed 30 days.
+     * - `date_from` must be within the last 90 days.
+     *
+     * Pagination (cursor-based):
+     * - Order is by `xml_cdr_uuid`. Default `limit` is 25, max 100.
+     * - Pass `starting_after` equal to the previous page's last `xml_cdr_uuid`.
+     *
+     * @group CDR
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID.
+     *
+     * @queryParam date_from string required ISO 8601 start of window. Example: 2026-04-01T00:00:00Z
+     * @queryParam date_to string required ISO 8601 end of window. Example: 2026-04-15T00:00:00Z
+     * @queryParam direction string One of: inbound, outbound, local.
+     * @queryParam status string One of: answered, missed, voicemail, abandoned, busy, no_answer, failed.
+     * @queryParam hangup_cause string FreeSWITCH hangup cause (e.g. NORMAL_CLEARING, USER_BUSY).
+     * @queryParam extension_uuid string Filter to a single extension.
+     * @queryParam queue_uuid string Filter to a single call-center queue.
+     * @queryParam caller_number string Substring match on caller_id_number.
+     * @queryParam destination_number string Substring match on destination_number / caller_destination.
+     * @queryParam min_duration int Seconds.
+     * @queryParam max_duration int Seconds.
+     * @queryParam min_mos float 1.0–5.0.
+     * @queryParam has_recording bool
+     * @queryParam limit int 1–100 (default 25).
+     * @queryParam starting_after string Last xml_cdr_uuid from the previous page.
+     */
+    public function index(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid, 'domain_uuid');
+
+        $filters = $this->filterParser->fromRequest($request);
+
+        $limit = $this->parseLimit($request);
+        $startingAfter = trim((string) $request->query('starting_after', '')) ?: null;
+
+        $query = $this->queries->baseQuery($domain_uuid, $filters->dateFromEpoch, $filters->dateToEpoch);
+        $this->queries->applyFilters($query, $filters);
+
+        [$rows, $hasMore] = $this->queries->paginate($query, $limit, $startingAfter);
+
+        $data = $rows->map(fn (CDR $cdr) => $this->toCallData($cdr))->all();
+
+        $payload = new CdrListResponseData(
+            object: 'list',
+            url: '/api/v1/domains/' . $domain_uuid . '/cdr/calls',
+            has_more: $hasMore,
+            data: $data,
+        );
+
+        return response()->json($payload->toArray(), 200);
+    }
+
+    /**
+     * Retrieve a single CDR.
+     *
+     * @group CDR
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID.
+     * @urlParam xml_cdr_uuid string required The CDR UUID.
+     */
+    public function show(Request $request, string $domain_uuid, string $xml_cdr_uuid)
+    {
+        $this->assertUuid($domain_uuid, 'domain_uuid');
+        $this->assertUuid($xml_cdr_uuid, 'xml_cdr_uuid');
+
+        $cdr = CDR::query()
+            ->where('domain_uuid', $domain_uuid)
+            ->where('xml_cdr_uuid', $xml_cdr_uuid)
+            ->first();
+
+        if (! $cdr) {
+            throw new ApiException(
+                404,
+                'invalid_request_error',
+                'CDR not found.',
+                'resource_missing',
+                'xml_cdr_uuid',
+            );
+        }
+
+        $recordingUrl = $this->resolveRecordingUrl($cdr);
+        $status = $this->statusResolver->resolve($cdr)->value;
+
+        $relatedLegs = CDR::query()
+            ->where('domain_uuid', $domain_uuid)
+            ->where(function ($q) use ($cdr) {
+                $q->where('originating_leg_uuid', $cdr->xml_cdr_uuid)
+                  ->orWhere('cc_member_session_uuid', $cdr->xml_cdr_uuid);
+            })
+            ->orderBy('start_epoch')
+            ->limit(50)
+            ->get()
+            ->map(fn (CDR $leg) => [
+                'xml_cdr_uuid' => (string) $leg->xml_cdr_uuid,
+                'direction' => $leg->direction,
+                'destination_number' => $leg->destination_number,
+                'duration' => (int) ($leg->duration ?? 0),
+                'billsec' => (int) ($leg->billsec ?? 0),
+                'hangup_cause' => $leg->hangup_cause,
+                'start_time' => $this->epochToIso($leg->start_epoch),
+            ])
+            ->all();
+
+        $payload = new CdrCallDetailData(
+            xml_cdr_uuid: (string) $cdr->xml_cdr_uuid,
+            object: 'cdr_call',
+            domain_uuid: (string) $cdr->domain_uuid,
+            direction: $cdr->direction,
+            status: $status,
+            caller_id_name: $cdr->caller_id_name,
+            caller_id_number: $cdr->caller_id_number,
+            destination_number: $cdr->destination_number,
+            caller_destination: $cdr->caller_destination,
+            start_time: $this->epochToIso($cdr->start_epoch),
+            answer_time: $this->epochToIso($cdr->answer_epoch),
+            end_time: $this->epochToIso($cdr->end_epoch),
+            duration: $cdr->duration === null ? null : (int) $cdr->duration,
+            billsec: $cdr->billsec === null ? null : (int) $cdr->billsec,
+            hangup_cause: $cdr->hangup_cause,
+            hangup_cause_q850: $cdr->hangup_cause_q850 === null ? null : (int) $cdr->hangup_cause_q850,
+            sip_hangup_disposition: $cdr->sip_hangup_disposition,
+            extension_uuid: $cdr->extension_uuid,
+            queue_uuid: $cdr->call_center_queue_uuid,
+            mos_inbound: $cdr->rtp_audio_in_mos === null ? null : (float) $cdr->rtp_audio_in_mos,
+            mos_outbound: null,
+            jitter_ms: null,
+            packet_loss: null,
+            cost: null,
+            cost_currency: null,
+            has_recording: ! empty($cdr->record_name),
+            recording_url: $recordingUrl,
+            sip_call_id: $cdr->sip_call_id,
+            pdd_ms: $cdr->pdd_ms === null ? null : (int) $cdr->pdd_ms,
+            read_codec: $cdr->read_codec ?? null,
+            read_rate: isset($cdr->read_rate) ? (int) $cdr->read_rate : null,
+            write_codec: $cdr->write_codec ?? null,
+            write_rate: isset($cdr->write_rate) ? (int) $cdr->write_rate : null,
+            remote_media_ip: $cdr->remote_media_ip ?? null,
+            network_addr: $cdr->network_addr ?? null,
+            accountcode: $cdr->accountcode ?? null,
+            call_flow: $this->decodeCallFlow($cdr),
+            related_legs: $relatedLegs,
+        );
+
+        return response()->json($payload->toArray(), 200);
+    }
+
+    private function toCallData(CDR $cdr): CdrCallData
+    {
+        return new CdrCallData(
+            xml_cdr_uuid: (string) $cdr->xml_cdr_uuid,
+            object: 'cdr_call',
+            domain_uuid: (string) $cdr->domain_uuid,
+            direction: $cdr->direction,
+            status: $this->statusResolver->resolve($cdr)->value,
+            caller_id_name: $cdr->caller_id_name,
+            caller_id_number: $cdr->caller_id_number,
+            destination_number: $cdr->destination_number,
+            caller_destination: $cdr->caller_destination,
+            start_time: $this->epochToIso($cdr->start_epoch),
+            answer_time: $this->epochToIso($cdr->answer_epoch),
+            end_time: $this->epochToIso($cdr->end_epoch),
+            duration: $cdr->duration === null ? null : (int) $cdr->duration,
+            billsec: $cdr->billsec === null ? null : (int) $cdr->billsec,
+            hangup_cause: $cdr->hangup_cause,
+            hangup_cause_q850: $cdr->hangup_cause_q850 === null ? null : (int) $cdr->hangup_cause_q850,
+            sip_hangup_disposition: $cdr->sip_hangup_disposition,
+            extension_uuid: $cdr->extension_uuid,
+            queue_uuid: $cdr->call_center_queue_uuid,
+            mos_inbound: $cdr->rtp_audio_in_mos === null ? null : (float) $cdr->rtp_audio_in_mos,
+            cost: null,
+            cost_currency: null,
+            has_recording: ! empty($cdr->record_name),
+            recording_url: null, // detail endpoint returns this; list stays light
+            sip_call_id: $cdr->sip_call_id,
+        );
+    }
+
+    private function resolveRecordingUrl(CDR $cdr): ?string
+    {
+        if (empty($cdr->record_name) && empty($cdr->archive_recording?->object_key)) {
+            return null;
+        }
+
+        $urls = $this->recordingUrls->urlsForCdr((string) $cdr->xml_cdr_uuid, 1800);
+        return $urls['audio_url'] ?? null;
+    }
+
+    private function decodeCallFlow(CDR $cdr): ?array
+    {
+        $raw = $cdr->call_flow ?? null;
+        if ($raw === null) {
+            return null;
+        }
+        if (is_array($raw)) {
+            return $raw;
+        }
+        $decoded = json_decode((string) $raw, true);
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function parseLimit(Request $request): int
+    {
+        $limit = (int) $request->query('limit', 25);
+        return max(1, min(100, $limit));
+    }
+
+    private function assertUuid(string $value, string $field): void
+    {
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $value)) {
+            throw new ApiException(
+                400,
+                'invalid_request_error',
+                'Invalid ' . $field . '.',
+                'invalid_request',
+                $field,
+            );
+        }
+    }
+
+    private function epochToIso($epoch): ?string
+    {
+        if (empty($epoch)) {
+            return null;
+        }
+        return gmdate('Y-m-d\TH:i:s\Z', (int) $epoch);
+    }
+}

--- a/app/Http/Controllers/Api/V1/CdrStatsController.php
+++ b/app/Http/Controllers/Api/V1/CdrStatsController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Data\Api\V1\Cdr\CdrFilterData;
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use App\Services\Cdr\CdrApiFilterParser;
+use App\Services\Cdr\CdrStatsService;
+use Illuminate\Http\Request;
+
+class CdrStatsController extends Controller
+{
+    public function __construct(
+        protected CdrStatsService $stats,
+        protected CdrApiFilterParser $filterParser,
+    ) {}
+
+    /**
+     * CDR summary statistics
+     *
+     * Aggregate counts, durations, ASR and ACD for the given domain + window.
+     *
+     * @group CDR
+     * @authenticated
+     */
+    public function summary(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid);
+        $filters = $this->filterParser->fromRequest($request);
+
+        $summary = $this->stats->summary($domain_uuid, $filters);
+
+        return response()->json([
+            'object' => 'cdr_stats_summary',
+            'domain_uuid' => $domain_uuid,
+            'window' => $this->windowBlock($filters),
+            ...$summary,
+        ], 200);
+    }
+
+    /**
+     * CDR stats grouped by direction.
+     *
+     * @group CDR
+     * @authenticated
+     */
+    public function byDirection(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid);
+        $filters = $this->filterParser->fromRequest($request);
+
+        return response()->json([
+            'object' => 'cdr_stats_by_direction',
+            'domain_uuid' => $domain_uuid,
+            'window' => $this->windowBlock($filters),
+            'data' => $this->stats->byDirection($domain_uuid, $filters),
+        ], 200);
+    }
+
+    /**
+     * CDR stats grouped by hangup cause.
+     *
+     * @group CDR
+     * @authenticated
+     */
+    public function byHangupCause(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid);
+        $filters = $this->filterParser->fromRequest($request);
+
+        return response()->json([
+            'object' => 'cdr_stats_by_hangup_cause',
+            'domain_uuid' => $domain_uuid,
+            'window' => $this->windowBlock($filters),
+            'data' => $this->stats->byHangupCause($domain_uuid, $filters),
+        ], 200);
+    }
+
+    private function windowBlock(CdrFilterData $filters): array
+    {
+        return [
+            'from' => gmdate('Y-m-d\TH:i:s\Z', $filters->dateFromEpoch),
+            'to' => gmdate('Y-m-d\TH:i:s\Z', $filters->dateToEpoch),
+        ];
+    }
+
+    private function assertUuid(string $value): void
+    {
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $value)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid domain_uuid.', 'invalid_request', 'domain_uuid');
+        }
+    }
+
+}

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -1,0 +1,516 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Data\Api\V1\DeletedResponseData;
+use App\Data\Api\V1\UserData;
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreUserRequest;
+use App\Http\Requests\Api\V1\UpdateUserRequest;
+use App\Models\Domain;
+use App\Models\Groups;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class UserController extends Controller
+{
+    private const ADMIN_GROUP_NAME = 'admin';
+
+    /**
+     * List users
+     *
+     * Returns users belonging to the specified domain.
+     *
+     * Access rules:
+     * - Caller must have access to the target domain (domain scope).
+     * - Caller must have the `user_view` permission.
+     *
+     * Pagination (cursor-based):
+     * - Both `limit` and `starting_after` are optional.
+     * - If `limit` is not provided, it defaults to 50.
+     * - If `starting_after` is not provided, results start from the beginning.
+     * - If `has_more` is true, request the next page by passing `starting_after`
+     *   equal to the last item's `user_uuid` from the previous response.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     * @queryParam limit integer Optional. Number of results (1-200). Defaults to 50. Example: 50
+     * @queryParam starting_after string Optional. Return results after this user UUID (cursor). Example: c0ec8113-aa15-40ac-8437-47185dd9dcf4
+     *
+     * @response 200 scenario="Success" {
+     *   "object": "list",
+     *   "url": "/api/v1/domains/4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b/users",
+     *   "has_more": false,
+     *   "data": [
+     *     {
+     *       "user_uuid": "9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e",
+     *       "object": "user",
+     *       "domain_uuid": "4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b",
+     *       "username": "ada_lovelace",
+     *       "user_email": "ada.lovelace@example.com",
+     *       "first_name": "Ada",
+     *       "last_name": "Lovelace",
+     *       "name_formatted": "Ada Lovelace",
+     *       "user_enabled": true,
+     *       "is_domain_admin": true,
+     *       "language": "en-us",
+     *       "time_zone": "Europe/London",
+     *       "created_at": "2026-04-08 12:34:56"
+     *     }
+     *   ]
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid starting_after UUID" {"error":{"type":"invalid_request_error","message":"Invalid starting_after UUID.","code":"invalid_request","param":"starting_after"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     */
+    public function index(Request $request, string $domain_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $limit = (int) $request->input('limit', 50);
+        $limit = max(1, min(200, $limit));
+
+        $startingAfter = (string) $request->input('starting_after', '');
+
+        $query = QueryBuilder::for(User::class)
+            ->where('domain_uuid', $domain_uuid)
+            ->with(['user_adv_fields', 'user_groups', 'settings'])
+            ->defaultSort('user_uuid')
+            ->reorder('user_uuid')
+            ->limit($limit + 1);
+
+        if ($startingAfter !== '') {
+            if (! preg_match('/^[0-9a-fA-F-]{36}$/', $startingAfter)) {
+                throw new ApiException(400, 'invalid_request_error', 'Invalid starting_after UUID.', 'invalid_request', 'starting_after');
+            }
+            $query->where('user_uuid', '>', $startingAfter);
+        }
+
+        $rows = $query->get();
+        $hasMore = $rows->count() > $limit;
+        $rows = $rows->take($limit);
+
+        $data = $rows->map(fn (User $u) => UserData::fromModel($u));
+
+        return response()->json([
+            'object'   => 'list',
+            'url'      => "/api/v1/domains/{$domain_uuid}/users",
+            'has_more' => $hasMore,
+            'data'     => $data,
+        ], 200);
+    }
+
+    /**
+     * Retrieve a user
+     *
+     * Returns a single user from the specified domain.
+     *
+     * Access rules:
+     * - Caller must have access to the target domain (domain scope).
+     * - Caller must have the `user_view` permission.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     * @urlParam user_uuid string required The user UUID. Example: 9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e
+     *
+     * @response 200 scenario="Success" {
+     *   "user_uuid": "9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e",
+     *   "object": "user",
+     *   "domain_uuid": "4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b",
+     *   "username": "ada_lovelace",
+     *   "user_email": "ada.lovelace@example.com",
+     *   "first_name": "Ada",
+     *   "last_name": "Lovelace",
+     *   "name_formatted": "Ada Lovelace",
+     *   "user_enabled": true,
+     *   "is_domain_admin": true,
+     *   "language": "en-us",
+     *   "time_zone": "Europe/London",
+     *   "created_at": "2026-04-08 12:34:56"
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid user UUID" {"error":{"type":"invalid_request_error","message":"Invalid user UUID.","code":"invalid_request","param":"user_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     * @response 404 scenario="User not found" {"error":{"type":"invalid_request_error","message":"User not found.","code":"resource_missing","param":"user_uuid"}}
+     */
+    public function show(Request $request, string $domain_uuid, string $user_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->validateUserUuid($user_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $user = $this->loadUserOrFail($domain_uuid, $user_uuid);
+
+        return response()->json(UserData::fromModel($user)->toArray(), 200);
+    }
+
+    /**
+     * Create a user
+     *
+     * Creates a new user in the specified domain. Optionally promotes the user
+     * to a domain administrator by adding them to the global `admin` group with
+     * a `v_user_groups` row scoped to this domain.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     *
+     * @response 201 scenario="Created" {
+     *   "user_uuid": "9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e",
+     *   "object": "user",
+     *   "domain_uuid": "4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b",
+     *   "username": "ada_lovelace",
+     *   "user_email": "ada.lovelace@example.com",
+     *   "first_name": "Ada",
+     *   "last_name": "Lovelace",
+     *   "name_formatted": "Ada Lovelace",
+     *   "user_enabled": true,
+     *   "is_domain_admin": true,
+     *   "language": "en-us",
+     *   "time_zone": "Europe/London",
+     *   "created_at": "2026-04-08 12:34:56"
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     * @response 422 scenario="Validation error" {"error":{"type":"invalid_request_error","message":"The given data was invalid.","code":"invalid_request","param":null,"details":{"user_email":["A user with this email already exists."]}}}
+     */
+    public function store(StoreUserRequest $request, string $domain_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $validated = $request->validated();
+
+        try {
+            /** @var User $user */
+            $user = DB::transaction(function () use ($validated, $domain_uuid) {
+                $user = User::create([
+                    'username'     => (string) $validated['username'],
+                    'user_email'   => (string) $validated['user_email'],
+                    'password'     => Hash::make($validated['password']),
+                    'domain_uuid'  => $domain_uuid,
+                    'user_enabled' => $this->toTextBool($validated['user_enabled'] ?? true),
+                ]);
+
+                $user->user_adv_fields()->create([
+                    'first_name' => $validated['first_name'],
+                    'last_name'  => $validated['last_name'],
+                ]);
+
+                foreach (['language', 'time_zone'] as $field) {
+                    if (! array_key_exists($field, $validated)) {
+                        continue;
+                    }
+                    $user->settings()->create([
+                        'domain_uuid'              => $domain_uuid,
+                        'user_setting_category'    => 'domain',
+                        'user_setting_subcategory' => $field,
+                        'user_setting_name'        => $field === 'language' ? 'code' : 'name',
+                        'user_setting_value'       => $validated[$field],
+                        'user_setting_enabled'     => true,
+                    ]);
+                }
+
+                if (! empty($validated['is_domain_admin'])) {
+                    $this->assignAdminGroup($user, $domain_uuid);
+                }
+
+                return $user;
+            });
+
+            $user = $this->loadUserOrFail($domain_uuid, (string) $user->user_uuid);
+
+            return response()
+                ->json(UserData::fromModel($user)->toArray(), 201)
+                ->header('Location', "/api/v1/domains/{$domain_uuid}/users/{$user->user_uuid}");
+        } catch (ApiException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            logger('API User store error: ' . $e->getMessage() . ' at ' . $e->getFile() . ':' . $e->getLine());
+            throw new ApiException(500, 'api_error', 'Internal server error.', 'internal_error');
+        }
+    }
+
+    /**
+     * Update a user
+     *
+     * Updates an existing user. All fields are optional; omitted fields are
+     * left unchanged. Toggling `is_domain_admin` adds or removes the user's
+     * `admin` group membership for this domain.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     * @urlParam user_uuid string required The user UUID. Example: 9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e
+     *
+     * @response 200 scenario="Success" {
+     *   "user_uuid": "9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e",
+     *   "object": "user",
+     *   "domain_uuid": "4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b",
+     *   "username": "ada_lovelace",
+     *   "user_email": "ada.lovelace@example.com",
+     *   "first_name": "Ada",
+     *   "last_name": "Lovelace",
+     *   "name_formatted": "Ada Lovelace",
+     *   "user_enabled": true,
+     *   "is_domain_admin": false,
+     *   "language": "en-us",
+     *   "time_zone": "Europe/London",
+     *   "created_at": "2026-04-08 12:34:56"
+     * }
+     *
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid user UUID" {"error":{"type":"invalid_request_error","message":"Invalid user UUID.","code":"invalid_request","param":"user_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="Domain not found" {"error":{"type":"invalid_request_error","message":"Domain not found.","code":"resource_missing","param":"domain_uuid"}}
+     * @response 404 scenario="User not found" {"error":{"type":"invalid_request_error","message":"User not found.","code":"resource_missing","param":"user_uuid"}}
+     * @response 422 scenario="Validation error" {"error":{"type":"invalid_request_error","message":"The given data was invalid.","code":"invalid_request","param":null,"details":{"user_email":["A user with this email already exists."]}}}
+     */
+    public function update(UpdateUserRequest $request, string $domain_uuid, string $user_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->validateUserUuid($user_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $user = $this->loadUserOrFail($domain_uuid, $user_uuid);
+        $validated = $request->validated();
+
+        try {
+            DB::transaction(function () use ($validated, $user, $domain_uuid) {
+                // Direct user fields
+                $userUpdates = [];
+                foreach (['username', 'user_email'] as $f) {
+                    if (array_key_exists($f, $validated)) {
+                        $userUpdates[$f] = $validated[$f];
+                    }
+                }
+                if (array_key_exists('user_enabled', $validated)) {
+                    $userUpdates['user_enabled'] = $this->toTextBool($validated['user_enabled']);
+                }
+                if (array_key_exists('password', $validated)) {
+                    $userUpdates['password'] = Hash::make($validated['password']);
+                }
+                if (! empty($userUpdates)) {
+                    $user->update($userUpdates);
+                }
+
+                // Names live on user_adv_fields
+                if (array_key_exists('first_name', $validated) || array_key_exists('last_name', $validated)) {
+                    $advUpdates = [];
+                    if (array_key_exists('first_name', $validated)) $advUpdates['first_name'] = $validated['first_name'];
+                    if (array_key_exists('last_name', $validated))  $advUpdates['last_name']  = $validated['last_name'];
+                    $user->user_adv_fields()->updateOrCreate(
+                        ['user_uuid' => $user->user_uuid],
+                        $advUpdates
+                    );
+                }
+
+                // Settings (language / time_zone)
+                foreach (['language', 'time_zone'] as $field) {
+                    if (! array_key_exists($field, $validated)) {
+                        continue;
+                    }
+                    $user->settings()->updateOrCreate(
+                        [
+                            'domain_uuid'              => $user->domain_uuid,
+                            'user_setting_category'    => 'domain',
+                            'user_setting_subcategory' => $field,
+                        ],
+                        [
+                            'user_setting_name'    => $field === 'language' ? 'code' : 'name',
+                            'user_setting_value'   => $validated[$field],
+                            'user_setting_enabled' => true,
+                        ]
+                    );
+                }
+
+                // Domain admin toggle
+                if (array_key_exists('is_domain_admin', $validated)) {
+                    if ($validated['is_domain_admin']) {
+                        $this->assignAdminGroup($user, $domain_uuid);
+                    } else {
+                        $this->removeAdminGroup($user, $domain_uuid);
+                    }
+                }
+            });
+
+            $user = $this->loadUserOrFail($domain_uuid, $user_uuid);
+
+            return response()->json(UserData::fromModel($user)->toArray(), 200);
+        } catch (ApiException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            logger('API User update error: ' . $e->getMessage() . ' at ' . $e->getFile() . ':' . $e->getLine());
+            throw new ApiException(500, 'api_error', 'Internal server error.', 'internal_error');
+        }
+    }
+
+    /**
+     * Delete a user
+     *
+     * Permanently deletes a user, including their adv fields, settings, group
+     * memberships, and any cross-domain permission rows. This is irreversible.
+     *
+     * @group Users
+     * @authenticated
+     *
+     * @urlParam domain_uuid string required The domain UUID. Example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+     * @urlParam user_uuid string required The user UUID. Example: 9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e
+     *
+     * @response 200 scenario="Success" {"object":"user","uuid":"9c6c2a5e-1ab1-4a0e-8d7f-cb8b2a4d111e","deleted":true}
+     * @response 400 scenario="Invalid domain UUID" {"error":{"type":"invalid_request_error","message":"Invalid domain UUID.","code":"invalid_request","param":"domain_uuid"}}
+     * @response 400 scenario="Invalid user UUID" {"error":{"type":"invalid_request_error","message":"Invalid user UUID.","code":"invalid_request","param":"user_uuid"}}
+     * @response 401 scenario="Unauthenticated" {"error":{"type":"authentication_error","message":"Unauthenticated.","code":"unauthenticated"}}
+     * @response 404 scenario="User not found" {"error":{"type":"invalid_request_error","message":"User not found.","code":"resource_missing","param":"user_uuid"}}
+     */
+    public function destroy(Request $request, string $domain_uuid, string $user_uuid)
+    {
+        $this->requireAuth($request);
+        $this->validateDomainUuid($domain_uuid);
+        $this->validateUserUuid($user_uuid);
+        $this->loadDomainOrFail($domain_uuid);
+
+        $user = $this->loadUserOrFail($domain_uuid, $user_uuid);
+
+        try {
+            DB::transaction(function () use ($user) {
+                $user->user_groups()->delete();
+                $user->user_adv_fields()->delete();
+                $user->settings()->delete();
+                $user->domain_permissions()->delete();
+                $user->domain_group_permissions()->delete();
+                $user->delete();
+            });
+
+            $payload = DeletedResponseData::from([
+                'uuid'    => (string) $user_uuid,
+                'object'  => 'user',
+                'deleted' => true,
+            ]);
+
+            return response()->json($payload->toArray(), 200);
+        } catch (\Throwable $e) {
+            logger('API User delete error: ' . $e->getMessage() . ' at ' . $e->getFile() . ':' . $e->getLine());
+            throw new ApiException(500, 'api_error', 'Internal server error.', 'internal_error');
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------
+
+    private function requireAuth(Request $request): void
+    {
+        if (! $request->user()) {
+            throw new ApiException(401, 'authentication_error', 'Unauthenticated.', 'unauthenticated');
+        }
+    }
+
+    private function validateDomainUuid(string $domain_uuid): void
+    {
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $domain_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid domain UUID.', 'invalid_request', 'domain_uuid');
+        }
+    }
+
+    private function validateUserUuid(string $user_uuid): void
+    {
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $user_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid user UUID.', 'invalid_request', 'user_uuid');
+        }
+    }
+
+    private function loadDomainOrFail(string $domain_uuid): Domain
+    {
+        $domain = Domain::query()->where('domain_uuid', $domain_uuid)->first(['domain_uuid', 'domain_name']);
+        if (! $domain) {
+            throw new ApiException(404, 'invalid_request_error', 'Domain not found.', 'resource_missing', 'domain_uuid');
+        }
+        return $domain;
+    }
+
+    private function loadUserOrFail(string $domain_uuid, string $user_uuid): User
+    {
+        $user = User::query()
+            ->with(['user_adv_fields', 'user_groups', 'settings'])
+            ->where('domain_uuid', $domain_uuid)
+            ->where('user_uuid', $user_uuid)
+            ->first();
+
+        if (! $user) {
+            throw new ApiException(404, 'invalid_request_error', 'User not found.', 'resource_missing', 'user_uuid');
+        }
+        return $user;
+    }
+
+    private function assignAdminGroup(User $user, string $domain_uuid): void
+    {
+        // Already an admin in this domain? noop.
+        $exists = $user->user_groups()
+            ->where('group_name', self::ADMIN_GROUP_NAME)
+            ->where('domain_uuid', $domain_uuid)
+            ->exists();
+        if ($exists) {
+            return;
+        }
+
+        $group = Groups::query()
+            ->where('group_name', self::ADMIN_GROUP_NAME)
+            ->whereNull('domain_uuid')
+            ->first();
+
+        if (! $group) {
+            // Should never happen on a properly seeded install.
+            throw new ApiException(
+                500,
+                'api_error',
+                'Admin group is not configured on this server.',
+                'internal_error'
+            );
+        }
+
+        $user->user_groups()->create([
+            'group_uuid'  => $group->group_uuid,
+            'group_name'  => self::ADMIN_GROUP_NAME,
+            'domain_uuid' => $domain_uuid,
+        ]);
+    }
+
+    private function removeAdminGroup(User $user, string $domain_uuid): void
+    {
+        $user->user_groups()
+            ->where('group_name', self::ADMIN_GROUP_NAME)
+            ->where('domain_uuid', $domain_uuid)
+            ->delete();
+    }
+
+    private function toTextBool($value): string
+    {
+        if (is_bool($value)) return $value ? 'true' : 'false';
+        if (is_string($value) && in_array(strtolower($value), ['true', 'false'], true)) {
+            return strtolower($value);
+        }
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false';
+    }
+}

--- a/app/Http/Controllers/ExtensionsController.php
+++ b/app/Http/Controllers/ExtensionsController.php
@@ -583,7 +583,9 @@ class ExtensionsController extends Controller
                 ->get([
                     'destination_uuid',
                     'destination_number',
+                    'destination_prefix',
                     'destination_description',
+                    'domain_uuid',
                 ])
                 ->each->append('label', 'destination_number_e164')
                 ->map(function ($destination) {
@@ -814,8 +816,10 @@ class ExtensionsController extends Controller
             ->get([
                 'destination_uuid',
                 'destination_number',
+                'destination_prefix',
                 'destination_enabled',
                 'destination_description',
+                'domain_uuid',
                 DB::raw("coalesce(destination_description, 'n/a') as destination_description"),
             ])
             ->sortBy('destination_description')
@@ -833,18 +837,9 @@ class ExtensionsController extends Controller
             );
         }
 
-        $destinations = $destinations->map(function ($destination) use ($countryCode, $currentCallerIdE164) {
-            $formattedNumber = formatPhoneNumber(
-                $destination->destination_number,
-                $countryCode,
-                PhoneNumberFormat::NATIONAL
-            );
-
-            $destinationE164 = formatPhoneNumber(
-                $destination->destination_number,
-                $countryCode,
-                PhoneNumberFormat::E164
-            );
+        $destinations = $destinations->map(function ($destination) use ($currentCallerIdE164) {
+            $formattedNumber = $destination->destination_number_formatted;
+            $destinationE164 = $destination->destination_number_e164;
 
             return [
                 'destination_uuid' => $destination->destination_uuid,
@@ -890,14 +885,8 @@ class ExtensionsController extends Controller
         CauserResolver::setCauser($extension);
 
         try {
-            $countryCode = get_domain_setting('country', $extension->domain_uuid) ?? 'US';
-
             if ($request->set === true || $request->set === 'true') {
-                $extension->outbound_caller_id_number = formatPhoneNumber(
-                    $destination->destination_number,
-                    $countryCode,
-                    PhoneNumberFormat::E164
-                );
+                $extension->outbound_caller_id_number = $destination->destination_number_e164;
             } else {
                 $extension->outbound_caller_id_number = null;
             }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -71,5 +71,6 @@ class Kernel extends HttpKernel
         'api.cookie.auth' => \App\Http\Middleware\RequireCookieAuthForSpaRequests::class,
         'api.token.auth' => \App\Http\Middleware\RequireBearerToken::class,
         'user.authorize' => \App\Http\Middleware\AuthorizeUser::class,
+        'cdr.scope' => \App\Http\Middleware\ResolveCdrScope::class,
     ];
 }

--- a/app/Http/Middleware/ResolveCdrScope.php
+++ b/app/Http/Middleware/ResolveCdrScope.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Exceptions\ApiException;
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * Enforces tenant vs global scope on CDR API routes.
+ *
+ * A PersonalAccessToken with `domain_uuid` set is a tenant token: it may only
+ * access routes whose `{domain_uuid}` path parameter matches. A token with a
+ * null `domain_uuid` is a global token: it may access any domain, but when
+ * reaching a tenant-scoped route (one with `{domain_uuid}`) it must still
+ * carry the `cdr:all-domains` ability or a user permission is enforced by
+ * `user.authorize:cdr_api_read_all_domains` on the route.
+ *
+ * Global-only routes (no `{domain_uuid}` in the path) require the token to
+ * carry the `cdr:all-domains` ability — tenant tokens are rejected with 403.
+ */
+class ResolveCdrScope
+{
+    public function handle(Request $request, Closure $next, string $mode = 'tenant')
+    {
+        $token = $this->currentToken($request);
+
+        if ($token === null) {
+            throw new ApiException(
+                401,
+                'authentication_error',
+                'Unauthenticated.',
+                'unauthenticated',
+            );
+        }
+
+        $tokenDomain = $token->domain_uuid ? (string) $token->domain_uuid : null;
+        $isGlobalToken = $tokenDomain === null;
+
+        if ($mode === 'global') {
+            if (! $isGlobalToken) {
+                throw new ApiException(
+                    403,
+                    'invalid_request_error',
+                    'This endpoint requires a global admin token.',
+                    'forbidden_scope',
+                );
+            }
+
+            return $next($request);
+        }
+
+        // Tenant-scoped route: URL must carry {domain_uuid}
+        $pathDomain = (string) $request->route('domain_uuid');
+
+        if ($pathDomain === '') {
+            throw new ApiException(
+                400,
+                'invalid_request_error',
+                'Missing domain_uuid on tenant-scoped route.',
+                'invalid_request',
+                'domain_uuid',
+            );
+        }
+
+        if (! $isGlobalToken && $tokenDomain !== $pathDomain) {
+            throw new ApiException(
+                403,
+                'invalid_request_error',
+                'This token is not permitted to access that domain.',
+                'forbidden_domain',
+                'domain_uuid',
+            );
+        }
+
+        // Expose the resolved domain for downstream consumers
+        $request->attributes->set('cdr_domain_uuid', $pathDomain);
+        $request->attributes->set('cdr_token_is_global', $isGlobalToken);
+
+        return $next($request);
+    }
+
+    private function currentToken(Request $request): ?PersonalAccessToken
+    {
+        $bearer = $request->bearerToken();
+        if (! $bearer) {
+            return null;
+        }
+
+        return PersonalAccessToken::findToken($bearer);
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreUserRequest.php
+++ b/app/Http/Requests/Api/V1/StoreUserRequest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+
+class StoreUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // API uses route middleware for permissions + domain scope
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'first_name'      => ['required', 'string', 'max:100'],
+            'last_name'       => ['required', 'string', 'max:100'],
+            'user_email'      => ['required', 'email', 'max:255', 'unique:v_users,user_email'],
+            'username'        => ['sometimes', 'nullable', 'string', 'max:255', 'unique:v_users,username'],
+            'password'        => ['required', 'string', 'min:12'],
+            'is_domain_admin' => ['sometimes', 'boolean'],
+            'user_enabled'    => ['sometimes', 'boolean'],
+            'language'        => ['sometimes', 'nullable', 'string', 'max:10'],
+            'time_zone'       => ['sometimes', 'nullable', 'string', 'max:64'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        // Derive username from first_name + last_name if not supplied,
+        // matching app/Http/Controllers/UsersController@store behavior.
+        if (! $this->filled('username') && $this->filled('first_name')) {
+            $username = Str::slug((string) $this->input('first_name'), '_');
+            if ($this->filled('last_name')) {
+                $username .= '_' . Str::slug((string) $this->input('last_name'), '_');
+            }
+            $this->merge(['username' => $username]);
+        }
+    }
+
+    public function messages(): array
+    {
+        return [
+            'user_email.unique' => 'A user with this email already exists.',
+            'username.unique'   => 'A user with this username already exists.',
+            'password.min'      => 'The password must be at least 12 characters long.',
+        ];
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            'first_name' => [
+                'description' => 'First name of the user.',
+                'example'     => 'Ada',
+            ],
+            'last_name' => [
+                'description' => 'Last name of the user.',
+                'example'     => 'Lovelace',
+            ],
+            'user_email' => [
+                'description' => 'Login email address. Must be globally unique.',
+                'example'     => 'ada.lovelace@example.com',
+            ],
+            'username' => [
+                'description' => 'Optional login username. If omitted it is derived from first_name + last_name.',
+                'example'     => 'ada_lovelace',
+            ],
+            'password' => [
+                'description' => 'Initial password. Minimum 12 characters. Stored hashed via bcrypt.',
+                'example'     => 'correcthorsebatterystaple',
+            ],
+            'is_domain_admin' => [
+                'description' => 'When true, the user is added to the `admin` group for the URL domain — making them a domain administrator. Default: false.',
+                'example'     => true,
+            ],
+            'user_enabled' => [
+                'description' => 'Whether the user can log in. Defaults to true.',
+                'example'     => true,
+            ],
+            'language' => [
+                'description' => 'Preferred UI language code.',
+                'example'     => 'en-us',
+            ],
+            'time_zone' => [
+                'description' => 'IANA time zone name.',
+                'example'     => 'Europe/London',
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateUserRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateUserRequest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // API uses route middleware for permissions + domain scope
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $userUuid = (string) $this->route('user_uuid');
+
+        return [
+            'first_name'      => ['sometimes', 'string', 'max:100'],
+            'last_name'       => ['sometimes', 'string', 'max:100'],
+            'user_email'      => [
+                'sometimes',
+                'email',
+                'max:255',
+                Rule::unique('v_users', 'user_email')->ignore($userUuid, 'user_uuid'),
+            ],
+            'username'        => [
+                'sometimes',
+                'string',
+                'max:255',
+                Rule::unique('v_users', 'username')->ignore($userUuid, 'user_uuid'),
+            ],
+            'password'        => ['sometimes', 'string', 'min:12'],
+            'is_domain_admin' => ['sometimes', 'boolean'],
+            'user_enabled'    => ['sometimes', 'boolean'],
+            'language'        => ['sometimes', 'nullable', 'string', 'max:10'],
+            'time_zone'       => ['sometimes', 'nullable', 'string', 'max:64'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'user_email.unique' => 'A user with this email already exists.',
+            'username.unique'   => 'A user with this username already exists.',
+            'password.min'      => 'The password must be at least 12 characters long.',
+        ];
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            'first_name'      => ['description' => 'First name of the user.',           'example' => 'Ada'],
+            'last_name'       => ['description' => 'Last name of the user.',            'example' => 'Lovelace'],
+            'user_email'      => ['description' => 'Login email address.',              'example' => 'ada.lovelace@example.com'],
+            'username'        => ['description' => 'Login username.',                   'example' => 'ada_lovelace'],
+            'password'        => ['description' => 'New password (min 12 chars). Hashed before storage.', 'example' => 'correcthorsebatterystaple'],
+            'is_domain_admin' => [
+                'description' => 'When true, ensure user is in the domain `admin` group. When false, remove them from it.',
+                'example'     => false,
+            ],
+            'user_enabled'    => ['description' => 'Whether the user can log in.', 'example' => true],
+            'language'        => ['description' => 'Preferred UI language code.', 'example' => 'en-us'],
+            'time_zone'       => ['description' => 'IANA time zone name.',        'example' => 'Europe/London'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreAiAgentKbDocumentRequest.php
+++ b/app/Http/Requests/StoreAiAgentKbDocumentRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAiAgentKbDocumentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'document_type' => 'required|in:file,url,text',
+            'name'          => 'required|string|max:255',
+            'file'          => 'required_if:document_type,file|file|mimes:pdf,txt,docx,html,htm,epub,md|max:20480',
+            'url'           => 'required_if:document_type,url|nullable|url|max:2048',
+            'text'          => 'required_if:document_type,text|nullable|string|max:50000',
+        ];
+    }
+}

--- a/app/Http/Requests/StorePhoneNumberRequest.php
+++ b/app/Http/Requests/StorePhoneNumberRequest.php
@@ -144,18 +144,26 @@ class StorePhoneNumberRequest extends FormRequest
 
     public function prepareForValidation(): void
     {
-        $phone = $this->get('destination_number');
-        $prefix = $this->get('destination_prefix');
+        $phone = (string) $this->get('destination_number');
+        $prefix = preg_replace('/\D/', '', (string) $this->get('destination_prefix'));
+        $digits = preg_replace('/\D/', '', $phone);
 
-        try {
-            $this->merge([
-                'destination_number' => str_replace('+1', '', (new PhoneNumber($phone, "US"))->formatE164()),
-            ]);
-        } catch (NumberParseException $e) {
-            $this->merge([
-                'destination_number' => $phone
-            ]);
+        // If the user included the country code in the phone field, strip it
+        // so the two fields stay consistent (prefix + national significant number).
+        if ($prefix !== '' && str_starts_with($digits, $prefix)) {
+            $digits = substr($digits, strlen($prefix));
         }
+
+        // UK/EU national numbers carry a leading trunk 0 — strip it so the
+        // stored NSN is carrier-agnostic (the dialplan regex handles both forms).
+        if ($digits !== '' && $digits[0] === '0') {
+            $digits = ltrim($digits, '0');
+        }
+
+        $this->merge([
+            'destination_prefix' => $prefix !== '' ? $prefix : null,
+            'destination_number' => $digits,
+        ]);
 
         if ($this->has('destination_conditions')) {
             $destinationConditions = [];

--- a/app/Jobs/SendIncomingCallPushJob.php
+++ b/app/Jobs/SendIncomingCallPushJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Models\Domain;
 use App\Models\Extensions;
 use App\Services\ApnsPushService;
 use Illuminate\Bus\Queueable;
@@ -28,19 +29,31 @@ class SendIncomingCallPushJob implements ShouldQueue
     public function handle(ApnsPushService $apns): void
     {
         $extensionUuid = $this->data['extension_uuid'] ?? null;
+        $extensionNumber = $this->data['extension_number'] ?? null;
+        $domainName = $this->data['domain_name'] ?? null;
         $callerIdName = $this->data['caller_id_name'] ?? 'Unknown';
         $callerIdNumber = $this->data['caller_id_number'] ?? '';
         $callUuid = $this->data['call_uuid'] ?? '';
 
-        if (!$extensionUuid) {
-            Log::warning('[IncomingCallPush] Missing extension_uuid', $this->data);
+        $extension = null;
+        if ($extensionUuid) {
+            $extension = Extensions::where('extension_uuid', $extensionUuid)->first();
+        }
+        if (!$extension && $extensionNumber && $domainName) {
+            $domain = Domain::where('domain_name', $domainName)->first();
+            if ($domain) {
+                $extension = Extensions::where('domain_uuid', $domain->domain_uuid)
+                    ->where('extension', $extensionNumber)
+                    ->first();
+            }
+        }
+        if (!$extension) {
+            Log::warning('[IncomingCallPush] Extension not found', $this->data);
             return;
         }
-
-        $extension = Extensions::where('extension_uuid', $extensionUuid)->first();
-        if (!$extension || !$extension->apns_voip_token) {
+        if (!$extension->apns_voip_token) {
             Log::info('[IncomingCallPush] No push token for extension', [
-                'extension_uuid' => $extensionUuid,
+                'extension_uuid' => $extension->extension_uuid,
             ]);
             return;
         }

--- a/app/Models/AiAgent.php
+++ b/app/Models/AiAgent.php
@@ -41,6 +41,11 @@ class AiAgent extends Model
         return $this->belongsTo(Domain::class, 'domain_uuid', 'domain_uuid');
     }
 
+    public function kbDocuments()
+    {
+        return $this->hasMany(AiAgentKbDocument::class, 'ai_agent_uuid', 'ai_agent_uuid');
+    }
+
     public function getId()
     {
         return $this->agent_extension;

--- a/app/Models/AiAgentKbDocument.php
+++ b/app/Models/AiAgentKbDocument.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AiAgentKbDocument extends Model
+{
+    use HasFactory, \App\Models\Traits\TraitUuid;
+
+    protected $table = 'v_ai_agent_kb_documents';
+
+    public $timestamps = false;
+
+    protected $primaryKey = 'kb_document_uuid';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'kb_document_uuid',
+        'ai_agent_uuid',
+        'domain_uuid',
+        'document_type',
+        'elevenlabs_documentation_id',
+        'name',
+        'file_path',
+        'file_mime_type',
+        'file_size',
+        'url',
+        'text_content',
+        'sync_status',
+        'sync_error',
+        'insert_date',
+        'insert_user',
+        'update_date',
+        'update_user',
+    ];
+
+    public function aiAgent()
+    {
+        return $this->belongsTo(AiAgent::class, 'ai_agent_uuid', 'ai_agent_uuid');
+    }
+}

--- a/app/Models/Destinations.php
+++ b/app/Models/Destinations.php
@@ -82,12 +82,31 @@ class Destinations extends Model
 
     public function getDestinationNumberFormattedAttribute()
     {
-        return formatPhoneNumber($this->destination_number, 'US', PhoneNumberFormat::NATIONAL);
+        $countryCode = $this->domain_uuid
+            ? (get_domain_setting('country', $this->domain_uuid) ?? 'US')
+            : 'US';
+
+        return formatPhoneNumber($this->destination_number_e164, $countryCode, PhoneNumberFormat::NATIONAL);
     }
 
     public function getDestinationNumberE164Attribute()
     {
-        return formatPhoneNumber($this->destination_number, 'US', PhoneNumberFormat::E164);
+        $number = preg_replace('/\D/', '', (string) $this->destination_number);
+
+        if ($number === '') {
+            return '';
+        }
+
+        if (str_starts_with((string) $this->destination_number, '+')) {
+            return '+' . $number;
+        }
+
+        $prefix = preg_replace('/\D/', '', (string) $this->destination_prefix);
+        if ($prefix !== '' && !str_starts_with($number, $prefix)) {
+            return '+' . $prefix . $number;
+        }
+
+        return '+' . $number;
     }
 
     public function getRoutingOptionsAttribute()

--- a/app/Models/Extensions.php
+++ b/app/Models/Extensions.php
@@ -170,6 +170,25 @@ class Extensions extends Model
         return formatPhoneNumber($this->outbound_caller_id_number, 'US', PhoneNumberFormat::E164);
     }
 
+    public function setOutboundCallerIdNumberAttribute($value)
+    {
+        $this->attributes['outbound_caller_id_number'] = $this->normalizeCallerIdNumber($value);
+    }
+
+    public function setEmergencyCallerIdNumberAttribute($value)
+    {
+        $this->attributes['emergency_caller_id_number'] = $this->normalizeCallerIdNumber($value);
+    }
+
+    protected function normalizeCallerIdNumber($value)
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+        // FusionPBX OUTBOUND_CALLER_ID dialplan validates with /^\d{6,25}$/ — '+' breaks it.
+        return ltrim((string) $value, '+');
+    }
+
     /**
      * This gets you “all possible” voicemails where ID matches extension, regardless of domain.
      * Further filtering by domain is REQUIRED to avoid false positives and PERFORMANCE ISSUES  

--- a/app/Models/Sanctum/PersonalAccessToken.php
+++ b/app/Models/Sanctum/PersonalAccessToken.php
@@ -11,4 +11,12 @@ class PersonalAccessToken extends SanctumPersonalAccessToken
     use \App\Models\Traits\TraitUuid;
     protected $primaryKey = "id";
     protected $keyType = "string";
+
+    protected $fillable = [
+        'name',
+        'token',
+        'abilities',
+        'expires_at',
+        'domain_uuid',
+    ];
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -53,6 +53,13 @@ class AppServiceProvider extends ServiceProvider
     public function register()
     {
         Sanctum::ignoreMigrations();
+
+        $this->app->singleton(\App\Services\Cdr\CdrApiFilterParser::class, function ($app) {
+            return new \App\Services\Cdr\CdrApiFilterParser(
+                maxWindowSeconds: (int) config('cdr.api_max_window_seconds', 30 * 86400),
+                maxAgeSeconds: (int) config('cdr.api_max_age_seconds', 90 * 86400),
+            );
+        });
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -72,5 +72,11 @@ class RouteServiceProvider extends ServiceProvider
                     return response('', 429);
                 });
         });
+
+        // CDR stats endpoints are expensive — tighter limiter, keyed by token.
+        RateLimiter::for('cdr-stats', function (Request $request) {
+            $key = $request->bearerToken() ?: (optional($request->user())->id ?: $request->ip());
+            return Limit::perMinute(30)->by('cdr-stats:' . $key);
+        });
     }
 }

--- a/app/Services/Cdr/CallStatusResolver.php
+++ b/app/Services/Cdr/CallStatusResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Services\Cdr;
+
+use App\Enums\Cdr\CallStatus;
+
+/**
+ * Derives a normalized CallStatus from the raw FreeSWITCH CDR columns.
+ *
+ * This mirrors the logic used by the Inertia Vue CDR page so API consumers
+ * and UI consumers agree on what a call's status is.
+ */
+class CallStatusResolver
+{
+    public function resolve(object $cdr): CallStatus
+    {
+        $voicemail = (bool) ($cdr->voicemail_message ?? false);
+        if ($voicemail) {
+            return CallStatus::Voicemail;
+        }
+
+        $missed = (bool) ($cdr->missed_call ?? false);
+        $hangup = (string) ($cdr->hangup_cause ?? '');
+        $ccCancel = (string) ($cdr->cc_cancel_reason ?? '');
+        $ccCause = (string) ($cdr->cc_cause ?? '');
+        $answerEpoch = (int) ($cdr->answer_epoch ?? 0);
+
+        if ($missed && $hangup === 'NORMAL_CLEARING' && $ccCancel === 'BREAK_OUT' && $ccCause === 'cancel') {
+            return CallStatus::Abandoned;
+        }
+
+        if ($missed && $hangup === 'NORMAL_CLEARING') {
+            return CallStatus::Missed;
+        }
+
+        if ($hangup === 'USER_BUSY') {
+            return CallStatus::Busy;
+        }
+
+        if (in_array($hangup, ['NO_ANSWER', 'NO_USER_RESPONSE', 'ALLOTTED_TIMEOUT'], true)) {
+            return CallStatus::NoAnswer;
+        }
+
+        if ($answerEpoch > 0 && $hangup === 'NORMAL_CLEARING') {
+            return CallStatus::Answered;
+        }
+
+        if ($answerEpoch === 0) {
+            return CallStatus::Failed;
+        }
+
+        return CallStatus::Answered;
+    }
+}

--- a/app/Services/Cdr/CdrApiFilterParser.php
+++ b/app/Services/Cdr/CdrApiFilterParser.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Services\Cdr;
+
+use App\Data\Api\V1\Cdr\CdrFilterData;
+use App\Enums\Cdr\CallDirection;
+use App\Enums\Cdr\CallStatus;
+use App\Exceptions\ApiException;
+use Illuminate\Http\Request;
+
+class CdrApiFilterParser
+{
+    public function __construct(
+        private readonly int $maxWindowSeconds = 30 * 86400,
+        private readonly int $maxAgeSeconds = 90 * 86400,
+    ) {}
+
+    public function fromRequest(Request $request): CdrFilterData
+    {
+        $dateFrom = (string) $request->query('date_from', '');
+        $dateTo = (string) $request->query('date_to', '');
+
+        if ($dateFrom === '' || $dateTo === '') {
+            throw new ApiException(
+                422,
+                'invalid_request_error',
+                'date_from and date_to are required.',
+                'parameter_missing',
+                $dateFrom === '' ? 'date_from' : 'date_to',
+            );
+        }
+
+        $fromEpoch = strtotime($dateFrom);
+        $toEpoch = strtotime($dateTo);
+
+        if ($fromEpoch === false || $toEpoch === false) {
+            throw new ApiException(
+                422,
+                'invalid_request_error',
+                'Invalid date format. Use ISO 8601 (e.g. 2026-04-01T00:00:00Z).',
+                'invalid_request',
+                $fromEpoch === false ? 'date_from' : 'date_to',
+            );
+        }
+
+        if ($toEpoch <= $fromEpoch) {
+            throw new ApiException(
+                422,
+                'invalid_request_error',
+                'date_to must be after date_from.',
+                'invalid_request',
+                'date_to',
+            );
+        }
+
+        if (($toEpoch - $fromEpoch) > $this->maxWindowSeconds) {
+            throw new ApiException(
+                422,
+                'invalid_request_error',
+                'Window exceeds the maximum of ' . ((int) ($this->maxWindowSeconds / 86400)) . ' days.',
+                'window_too_large',
+                'date_to',
+            );
+        }
+
+        if ((time() - $fromEpoch) > $this->maxAgeSeconds) {
+            throw new ApiException(
+                422,
+                'invalid_request_error',
+                'date_from is older than the retention window (' . ((int) ($this->maxAgeSeconds / 86400)) . ' days).',
+                'window_too_old',
+                'date_from',
+            );
+        }
+
+        $direction = CallDirection::tryFromLoose($request->query('direction'));
+        if ($request->query('direction') !== null && $direction === null) {
+            throw new ApiException(
+                422,
+                'invalid_request_error',
+                'Invalid direction. Expected: inbound, outbound, or local.',
+                'invalid_request',
+                'direction',
+            );
+        }
+
+        $status = CallStatus::tryFromLoose($request->query('status'));
+        if ($request->query('status') !== null && $status === null) {
+            throw new ApiException(
+                422,
+                'invalid_request_error',
+                'Invalid status.',
+                'invalid_request',
+                'status',
+            );
+        }
+
+        return new CdrFilterData(
+            dateFromEpoch: $fromEpoch,
+            dateToEpoch: $toEpoch,
+            direction: $direction,
+            status: $status,
+            hangupCause: $this->str($request->query('hangup_cause')),
+            extensionUuid: $this->str($request->query('extension_uuid')),
+            queueUuid: $this->str($request->query('queue_uuid')),
+            callerNumber: $this->str($request->query('caller_number')),
+            destinationNumber: $this->str($request->query('destination_number')),
+            minDuration: $this->intOrNull($request->query('min_duration')),
+            maxDuration: $this->intOrNull($request->query('max_duration')),
+            minMos: $this->floatOrNull($request->query('min_mos')),
+            hasRecording: $this->boolOrNull($request->query('has_recording')),
+        );
+    }
+
+    private function str($v): ?string
+    {
+        if ($v === null) return null;
+        $t = trim((string) $v);
+        return $t === '' ? null : $t;
+    }
+
+    private function intOrNull($v): ?int
+    {
+        $s = $this->str($v);
+        return $s === null ? null : (int) $s;
+    }
+
+    private function floatOrNull($v): ?float
+    {
+        $s = $this->str($v);
+        return $s === null ? null : (float) $s;
+    }
+
+    private function boolOrNull($v): ?bool
+    {
+        if ($v === null || $v === '') return null;
+        return filter_var($v, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+    }
+}

--- a/app/Services/Cdr/CdrQueryService.php
+++ b/app/Services/Cdr/CdrQueryService.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Services\Cdr;
+
+use App\Data\Api\V1\Cdr\CdrFilterData;
+use App\Enums\Cdr\CallStatus;
+use App\Models\CDR;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Domain-scoped CDR query builder for the API.
+ *
+ * Deliberately separate from the session-coupled CdrDataService so existing
+ * Inertia pages keep working without modification.
+ */
+class CdrQueryService
+{
+    /**
+     * Base query scoped to a single domain and a date window on start_epoch.
+     * Excludes LOSE_RACE + child legs to match the existing Vue CDR list.
+     */
+    public function baseQuery(string $domainUuid, int $fromEpoch, int $toEpoch): Builder
+    {
+        return CDR::query()
+            ->where('domain_uuid', $domainUuid)
+            ->where('start_epoch', '>=', $fromEpoch)
+            ->where('start_epoch', '<=', $toEpoch)
+            ->where(function ($q) {
+                $q->where('hangup_cause', '!=', 'LOSE_RACE')
+                  ->orWhereNull('hangup_cause');
+            })
+            ->whereNull('cc_member_session_uuid')
+            ->whereNull('originating_leg_uuid');
+    }
+
+    public function applyFilters(Builder $query, CdrFilterData $filters): Builder
+    {
+        if ($filters->direction !== null) {
+            $query->where('direction', $filters->direction->value);
+        }
+
+        if ($filters->hangupCause !== null) {
+            $query->where('hangup_cause', $filters->hangupCause);
+        }
+
+        if ($filters->extensionUuid !== null) {
+            $query->where('extension_uuid', $filters->extensionUuid);
+        }
+
+        if ($filters->queueUuid !== null) {
+            $query->where('call_center_queue_uuid', $filters->queueUuid);
+        }
+
+        if ($filters->callerNumber !== null && $filters->callerNumber !== '') {
+            $query->where('caller_id_number', 'ilike', '%' . $filters->callerNumber . '%');
+        }
+
+        if ($filters->destinationNumber !== null && $filters->destinationNumber !== '') {
+            $query->where(function ($q) use ($filters) {
+                $q->where('destination_number', 'ilike', '%' . $filters->destinationNumber . '%')
+                  ->orWhere('caller_destination', 'ilike', '%' . $filters->destinationNumber . '%');
+            });
+        }
+
+        if ($filters->minDuration !== null) {
+            $query->where('duration', '>=', $filters->minDuration);
+        }
+
+        if ($filters->maxDuration !== null) {
+            $query->where('duration', '<=', $filters->maxDuration);
+        }
+
+        if ($filters->minMos !== null) {
+            $query->where('rtp_audio_in_mos', '>=', $filters->minMos);
+        }
+
+        if ($filters->hasRecording === true) {
+            $query->whereNotNull('record_name')->where('record_name', '!=', '');
+        } elseif ($filters->hasRecording === false) {
+            $query->where(function ($q) {
+                $q->whereNull('record_name')->orWhere('record_name', '=', '');
+            });
+        }
+
+        if ($filters->status !== null) {
+            $this->applyStatus($query, $filters->status);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Cursor paginate on xml_cdr_uuid for stable pagination. Returns
+     * [Collection $rows, bool $hasMore].
+     */
+    public function paginate(Builder $query, int $limit, ?string $startingAfter = null): array
+    {
+        $query = $query->clone()
+            ->reorder('xml_cdr_uuid')
+            ->orderBy('xml_cdr_uuid');
+
+        if ($startingAfter !== null && $startingAfter !== '') {
+            $query->where('xml_cdr_uuid', '>', $startingAfter);
+        }
+
+        $rows = $query->limit($limit + 1)->get();
+        $hasMore = $rows->count() > $limit;
+
+        return [$rows->take($limit), $hasMore];
+    }
+
+    private function applyStatus(Builder $query, CallStatus $status): void
+    {
+        switch ($status) {
+            case CallStatus::Voicemail:
+                $query->where('voicemail_message', true);
+                break;
+
+            case CallStatus::Abandoned:
+                $query->where('voicemail_message', false)
+                      ->where('missed_call', true)
+                      ->where('hangup_cause', 'NORMAL_CLEARING')
+                      ->where('cc_cancel_reason', 'BREAK_OUT')
+                      ->where('cc_cause', 'cancel');
+                break;
+
+            case CallStatus::Missed:
+                $query->where('voicemail_message', false)
+                      ->where('missed_call', true)
+                      ->where('hangup_cause', 'NORMAL_CLEARING')
+                      ->where(function ($q) {
+                          $q->whereNull('cc_cancel_reason')->orWhere('cc_cancel_reason', '!=', 'BREAK_OUT');
+                      });
+                break;
+
+            case CallStatus::Busy:
+                $query->where('hangup_cause', 'USER_BUSY');
+                break;
+
+            case CallStatus::NoAnswer:
+                $query->whereIn('hangup_cause', ['NO_ANSWER', 'NO_USER_RESPONSE', 'ALLOTTED_TIMEOUT']);
+                break;
+
+            case CallStatus::Answered:
+                $query->where('answer_epoch', '>', 0)
+                      ->where('hangup_cause', 'NORMAL_CLEARING')
+                      ->where(function ($q) {
+                          $q->where('voicemail_message', false)
+                            ->where(function ($q2) {
+                                $q2->whereNull('missed_call')->orWhere('missed_call', false);
+                            });
+                      });
+                break;
+
+            case CallStatus::Failed:
+                $query->where(function ($q) {
+                    $q->whereNull('answer_epoch')->orWhere('answer_epoch', 0);
+                })
+                ->whereNotIn('hangup_cause', [
+                    'NORMAL_CLEARING', 'USER_BUSY',
+                    'NO_ANSWER', 'NO_USER_RESPONSE', 'ALLOTTED_TIMEOUT',
+                ]);
+                break;
+        }
+    }
+}

--- a/app/Services/Cdr/CdrStatsService.php
+++ b/app/Services/Cdr/CdrStatsService.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Services\Cdr;
+
+use App\Data\Api\V1\Cdr\CdrFilterData;
+use App\Models\CDR;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+class CdrStatsService
+{
+    public function __construct(protected CdrQueryService $queries) {}
+
+    /**
+     * Single-row summary for the domain + window + filters.
+     *
+     * @return array<string, mixed>
+     */
+    public function summary(string $domainUuid, CdrFilterData $filters): array
+    {
+        $row = $this->scopedQuery($domainUuid, $filters)
+            ->selectRaw($this->summaryExpressions())
+            ->first();
+
+        return $this->normalizeSummary($row);
+    }
+
+    /**
+     * Summary grouped by direction.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function byDirection(string $domainUuid, CdrFilterData $filters): array
+    {
+        $rows = $this->scopedQuery($domainUuid, $filters)
+            ->selectRaw('direction, ' . $this->summaryExpressions())
+            ->groupBy('direction')
+            ->orderBy('direction')
+            ->get();
+
+        return $rows->map(function ($r) {
+            $summary = $this->normalizeSummary($r);
+            $summary['direction'] = $r->direction ?? 'unknown';
+            return $summary;
+        })->all();
+    }
+
+    /**
+     * Failure-analysis breakdown on hangup cause + q.850 + SIP disposition.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function byHangupCause(string $domainUuid, CdrFilterData $filters): array
+    {
+        $total = (int) $this->scopedQuery($domainUuid, $filters)->count();
+
+        $rows = $this->scopedQuery($domainUuid, $filters)
+            ->selectRaw(
+                'hangup_cause, hangup_cause_q850, sip_hangup_disposition, ' .
+                'COUNT(*) AS calls, ' .
+                'COALESCE(SUM(duration),0) AS total_duration_sec, ' .
+                'COALESCE(SUM(billsec),0) AS total_billsec, ' .
+                'COALESCE(AVG(NULLIF(duration,0)),0) AS avg_duration_sec'
+            )
+            ->groupBy('hangup_cause', 'hangup_cause_q850', 'sip_hangup_disposition')
+            ->orderByRaw('COUNT(*) DESC')
+            ->get();
+
+        return $rows->map(function ($r) use ($total) {
+            $calls = (int) $r->calls;
+            return [
+                'hangup_cause' => $r->hangup_cause,
+                'hangup_cause_q850' => $r->hangup_cause_q850 === null ? null : (int) $r->hangup_cause_q850,
+                'sip_hangup_disposition' => $r->sip_hangup_disposition,
+                'calls' => $calls,
+                'pct_of_total' => $total > 0 ? round($calls / $total, 4) : 0.0,
+                'total_duration_sec' => (int) $r->total_duration_sec,
+                'total_billsec' => (int) $r->total_billsec,
+                'avg_duration_sec' => (float) round((float) $r->avg_duration_sec, 2),
+            ];
+        })->all();
+    }
+
+    protected function scopedQuery(string $domainUuid, CdrFilterData $filters): Builder
+    {
+        $query = $this->queries->baseQuery($domainUuid, $filters->dateFromEpoch, $filters->dateToEpoch);
+        return $this->queries->applyFilters($query, $filters);
+    }
+
+    protected function summaryExpressions(): string
+    {
+        return implode(', ', [
+            'COUNT(*) AS calls',
+            "SUM(CASE WHEN answer_epoch > 0 AND hangup_cause = 'NORMAL_CLEARING' AND (voicemail_message IS NULL OR voicemail_message = false) AND (missed_call IS NULL OR missed_call = false) THEN 1 ELSE 0 END) AS answered",
+            "SUM(CASE WHEN missed_call = true AND hangup_cause = 'NORMAL_CLEARING' AND (voicemail_message IS NULL OR voicemail_message = false) AND (cc_cancel_reason IS NULL OR cc_cancel_reason <> 'BREAK_OUT') THEN 1 ELSE 0 END) AS missed",
+            "SUM(CASE WHEN voicemail_message = true THEN 1 ELSE 0 END) AS voicemail",
+            "SUM(CASE WHEN missed_call = true AND hangup_cause = 'NORMAL_CLEARING' AND cc_cancel_reason = 'BREAK_OUT' AND cc_cause = 'cancel' THEN 1 ELSE 0 END) AS abandoned",
+            "SUM(CASE WHEN hangup_cause IN ('NO_ANSWER','NO_USER_RESPONSE','ALLOTTED_TIMEOUT') THEN 1 ELSE 0 END) AS no_answer",
+            "SUM(CASE WHEN hangup_cause = 'USER_BUSY' THEN 1 ELSE 0 END) AS busy",
+            "SUM(CASE WHEN (answer_epoch IS NULL OR answer_epoch = 0) AND hangup_cause NOT IN ('NORMAL_CLEARING','USER_BUSY','NO_ANSWER','NO_USER_RESPONSE','ALLOTTED_TIMEOUT') THEN 1 ELSE 0 END) AS failed",
+            'COALESCE(SUM(duration),0) AS total_duration_sec',
+            'COALESCE(SUM(billsec),0) AS total_billsec',
+            'COALESCE(AVG(NULLIF(duration,0)),0) AS avg_duration_sec',
+        ]);
+    }
+
+    protected function normalizeSummary($row): array
+    {
+        $calls = (int) ($row->calls ?? 0);
+        $answered = (int) ($row->answered ?? 0);
+        $busy = (int) ($row->busy ?? 0);
+        $noAnswer = (int) ($row->no_answer ?? 0);
+        $failed = (int) ($row->failed ?? 0);
+        $asrDenominator = $answered + $busy + $noAnswer + $failed;
+        $asr = $asrDenominator > 0 ? round($answered / $asrDenominator, 4) : 0.0;
+
+        $totalBillsec = (int) ($row->total_billsec ?? 0);
+        $acd = $answered > 0 ? (int) round($totalBillsec / $answered) : 0;
+
+        return [
+            'totals' => [
+                'calls' => $calls,
+                'answered' => $answered,
+                'missed' => (int) ($row->missed ?? 0),
+                'voicemail' => (int) ($row->voicemail ?? 0),
+                'abandoned' => (int) ($row->abandoned ?? 0),
+                'busy' => $busy,
+                'no_answer' => $noAnswer,
+                'failed' => $failed,
+            ],
+            'duration' => [
+                'total_sec' => (int) ($row->total_duration_sec ?? 0),
+                'total_billsec' => $totalBillsec,
+                'avg_sec' => (int) round((float) ($row->avg_duration_sec ?? 0)),
+            ],
+            'rates' => [
+                'asr' => $asr,
+                'acd_sec' => $acd,
+            ],
+            'cost' => [
+                'total' => null,
+                'currency' => null,
+            ],
+        ];
+    }
+}

--- a/app/Services/ElevenLabsConvaiService.php
+++ b/app/Services/ElevenLabsConvaiService.php
@@ -113,14 +113,30 @@ class ElevenLabsConvaiService
     }
 
     /**
-     * Create a SIP trunk phone number in ElevenLabs.
+     * Create an inbound SIP trunk phone number in ElevenLabs.
+     *
+     * Without an `inbound_trunk_config.allowed_addresses` allowlist the
+     * resulting number will not accept inbound SIP — INVITEs reach
+     * sip.rtc.elevenlabs.io, get 100 Processing, then are silently dropped.
      */
-    public function createSipTrunkPhoneNumber(string $label, string $phoneNumber): array
-    {
+    public function createSipTrunkPhoneNumber(
+        string $label,
+        string $phoneNumber,
+        array $allowedAddresses = [],
+        string $mediaEncryption = 'allowed'
+    ): array {
         $body = [
             'phone_number' => $phoneNumber,
-            'label' => $label,
+            'label'        => $label,
+            'provider'     => 'sip_trunk',
         ];
+
+        if (!empty($allowedAddresses)) {
+            $body['inbound_trunk_config'] = [
+                'allowed_addresses' => array_values($allowedAddresses),
+                'media_encryption'  => $mediaEncryption,
+            ];
+        }
 
         $response = $this->http()->post('v1/convai/phone-numbers', $body);
 
@@ -130,6 +146,33 @@ class ElevenLabsConvaiService
         }
 
         return $response->json();
+    }
+
+    /**
+     * Replace an existing ElevenLabs SIP trunk phone number with a freshly
+     * configured one (delete + recreate + reassign agent). Used by the
+     * ai-agents:resync-elevenlabs artisan command to backfill agents that
+     * were created before inbound_trunk_config support existed.
+     */
+    public function replaceSipTrunkPhoneNumber(
+        ?string $existingPhoneNumberId,
+        string $label,
+        string $phoneNumber,
+        array $allowedAddresses,
+        string $agentId
+    ): array {
+        if ($existingPhoneNumberId) {
+            $this->deletePhoneNumber($existingPhoneNumberId);
+        }
+
+        $created = $this->createSipTrunkPhoneNumber($label, $phoneNumber, $allowedAddresses);
+
+        $newId = $created['phone_number_id'] ?? null;
+        if ($newId && $agentId) {
+            $this->assignAgentToPhoneNumber($newId, $agentId);
+        }
+
+        return $created;
     }
 
     /**

--- a/app/Services/ElevenLabsConvaiService.php
+++ b/app/Services/ElevenLabsConvaiService.php
@@ -159,6 +159,134 @@ class ElevenLabsConvaiService
         }
     }
 
+    /**
+     * Upload a file to the ElevenLabs knowledge base.
+     * POST /v1/convai/knowledge-base/file
+     */
+    public function uploadKbFile(string $filePath, string $name): array
+    {
+        $response = $this->httpMultipart()
+            ->attach('file', file_get_contents($filePath), basename($filePath))
+            ->post('v1/convai/knowledge-base/file', [
+                ['name' => 'name', 'contents' => $name],
+            ]);
+
+        if (!$response->successful()) {
+            logger('ElevenLabs KB file upload error: ' . $response->body());
+            throw new RuntimeException('Failed to upload KB file: ' . ($response->json('detail.message') ?? $response->body()));
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Add a URL document to the ElevenLabs knowledge base.
+     * POST /v1/convai/knowledge-base/url
+     */
+    public function addKbUrl(string $url, string $name): array
+    {
+        $response = $this->http()->post('v1/convai/knowledge-base/url', [
+            'url'  => $url,
+            'name' => $name,
+        ]);
+
+        if (!$response->successful()) {
+            logger('ElevenLabs KB url add error: ' . $response->body());
+            throw new RuntimeException('Failed to add KB url: ' . ($response->json('detail.message') ?? $response->body()));
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Add a text snippet to the ElevenLabs knowledge base.
+     * POST /v1/convai/knowledge-base/text
+     */
+    public function addKbText(string $text, string $name): array
+    {
+        $response = $this->http()->post('v1/convai/knowledge-base/text', [
+            'text' => $text,
+            'name' => $name,
+        ]);
+
+        if (!$response->successful()) {
+            logger('ElevenLabs KB text add error: ' . $response->body());
+            throw new RuntimeException('Failed to add KB text: ' . ($response->json('detail.message') ?? $response->body()));
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Delete a knowledge base document.
+     * DELETE /v1/convai/knowledge-base/{documentation_id}
+     */
+    public function deleteKbDocument(string $documentationId): void
+    {
+        $response = $this->http()->delete("v1/convai/knowledge-base/{$documentationId}");
+
+        if (!$response->successful() && $response->status() !== 404) {
+            logger('ElevenLabs KB delete error: ' . $response->body());
+            throw new RuntimeException('Failed to delete KB document: ' . $response->body());
+        }
+    }
+
+    /**
+     * Set the agent's knowledge base array.
+     * Each entry: ['type' => 'file'|'url'|'text', 'id' => $documentationId, 'name' => $name]
+     * PATCH /v1/convai/agents/{agent_id}
+     */
+    public function setAgentKnowledgeBase(string $agentId, array $documents): array
+    {
+        $body = [
+            'conversation_config' => [
+                'agent' => [
+                    'prompt' => [
+                        'knowledge_base' => array_values(array_map(function ($d) {
+                            return [
+                                'type' => $d['type'],
+                                'id'   => $d['id'],
+                                'name' => $d['name'],
+                            ];
+                        }, $documents)),
+                    ],
+                ],
+            ],
+        ];
+
+        $response = $this->http()->patch("v1/convai/agents/{$agentId}", $body);
+
+        if (!$response->successful()) {
+            logger('ElevenLabs set agent KB error: ' . $response->body());
+            throw new RuntimeException('Failed to set agent knowledge base: ' . ($response->json('detail.message') ?? $response->body()));
+        }
+
+        return $response->json();
+    }
+
+    private function httpMultipart(): \Illuminate\Http\Client\PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl . '/')
+            ->timeout($this->timeout)
+            ->withHeaders([
+                'xi-api-key' => $this->apiKey,
+                'Accept'     => 'application/json',
+            ])
+            ->retry(
+                3,
+                500,
+                function ($exception) {
+                    if ($exception instanceof ConnectionException) {
+                        return true;
+                    }
+                    $response = method_exists($exception, 'response') ? $exception->response() : null;
+                    $status = $response?->status();
+                    return in_array($status, [429, 500, 502, 503, 504], true);
+                },
+                throw: false
+            );
+    }
+
     private function http(): \Illuminate\Http\Client\PendingRequest
     {
         return Http::baseUrl($this->baseUrl . '/')

--- a/app/Services/OutboundCallerIdFixer.php
+++ b/app/Services/OutboundCallerIdFixer.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\FusionCache;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Patches FusionPBX defaults that prevent outbound caller ID from reaching
+ * upstream SIP trunks.
+ *
+ * The stock FusionPBX OUTBOUND_CALLER_ID dialplan ends with an idempotent
+ * no-op ({@code set outbound_caller_id_number=${outbound_caller_id_number}})
+ * that never copies the extension's configured CID onto effective_caller_id
+ * or exports it as PAI. Combined with gateways shipping with
+ * {@code caller_id_in_from} unset (defaulting to false), the outbound INVITE
+ * carries only the gateway auth-user in From and the extension number in
+ * Remote-Party-ID — carriers then substitute their default trunk CLI.
+ *
+ * This runs at every deploy (via Ansible) so newly-provisioned domains get
+ * patched without a manual step.
+ */
+class OutboundCallerIdFixer
+{
+    public const BROKEN_ACTION_PATTERN =
+        '/(<condition field="\$\{outbound_caller_id_number\}" expression="\^\\\\d\{6,25\}\$" break="never">\s*\n)'
+        . '(\s*)<action application="set" data="outbound_caller_id_number=\$\{outbound_caller_id_number\}" inline="true"\/>/';
+
+    public const REPLACEMENT_FORMAT = "%s%s<action application=\"set\" data=\"effective_caller_id_number=\${outbound_caller_id_number}\" inline=\"true\"/>\n%s<action application=\"set\" data=\"effective_caller_id_name=\${outbound_caller_id_name}\" inline=\"true\"/>\n%s<action application=\"export\" data=\"sip_h_P-Asserted-Identity=<sip:\${outbound_caller_id_number}@\${domain_name}>\"/>";
+
+    /**
+     * @return array{dialplans_patched: int, gateways_patched: int}
+     */
+    public function run(): array
+    {
+        return [
+            'dialplans_patched' => $this->patchDialplans(),
+            'gateways_patched' => $this->patchGateways(),
+        ];
+    }
+
+    protected function patchDialplans(): int
+    {
+        $rows = DB::table('v_dialplans')
+            ->where('dialplan_name', 'OUTBOUND_CALLER_ID')
+            ->get(['dialplan_uuid', 'dialplan_xml']);
+
+        $patched = 0;
+
+        foreach ($rows as $row) {
+            $xml = $row->dialplan_xml;
+
+            if ($xml === null || $xml === '') {
+                continue;
+            }
+
+            // Already patched — effective_caller_id_number assignment is present.
+            if (strpos($xml, 'effective_caller_id_number=${outbound_caller_id_number}') !== false) {
+                continue;
+            }
+
+            $count = 0;
+            $newXml = preg_replace_callback(
+                self::BROKEN_ACTION_PATTERN,
+                fn ($m) => sprintf(self::REPLACEMENT_FORMAT, $m[1], $m[2], $m[2], $m[2]),
+                $xml,
+                -1,
+                $count,
+            );
+
+            if ($count > 0) {
+                DB::table('v_dialplans')
+                    ->where('dialplan_uuid', $row->dialplan_uuid)
+                    ->update([
+                        'dialplan_xml' => $newXml,
+                        'update_date' => date('Y-m-d H:i:s'),
+                    ]);
+                $patched++;
+            }
+        }
+
+        if ($patched > 0) {
+            FusionCache::clear('dialplan:public');
+        }
+
+        return $patched;
+    }
+
+    protected function patchGateways(): int
+    {
+        return DB::table('v_gateways')
+            ->where(function ($q) {
+                $q->whereNull('caller_id_in_from')->orWhere('caller_id_in_from', '');
+            })
+            ->update([
+                'caller_id_in_from' => 'true',
+                'update_date' => date('Y-m-d H:i:s'),
+            ]);
+    }
+}

--- a/app/Services/Tts/ElevenLabsTtsService.php
+++ b/app/Services/Tts/ElevenLabsTtsService.php
@@ -37,7 +37,7 @@ class ElevenLabsTtsService implements TtsProviderInterface
 
         $body = [
             'text'     => $input,
-            'model_id' => $options['model'] ?? 'eleven_multilingual_v2',
+            'model_id' => 'eleven_multilingual_v2',
         ];
 
         // Optional voice settings

--- a/app/Services/Tts/ElevenLabsTtsService.php
+++ b/app/Services/Tts/ElevenLabsTtsService.php
@@ -117,7 +117,6 @@ class ElevenLabsTtsService implements TtsProviderInterface
     public function getOutputFormats(): array
     {
         return [
-            ['value' => 'wav', 'label' => 'WAV (16-bit PCM)'],
             ['value' => 'mp3', 'label' => 'MP3 (128kbps)'],
             ['value' => 'ulaw', 'label' => 'u-law 8kHz (telephony)'],
             ['value' => 'pcm', 'label' => 'PCM 16kHz'],
@@ -130,11 +129,11 @@ class ElevenLabsTtsService implements TtsProviderInterface
     private function mapOutputFormat(string $format): string
     {
         return match ($format) {
-            'wav'  => 'pcm_44100',
             'mp3'  => 'mp3_44100_128',
+            'wav'  => 'mp3_44100_128',
             'ulaw' => 'ulaw_8000',
             'pcm'  => 'pcm_16000',
-            default => 'pcm_44100',
+            default => 'mp3_44100_128',
         };
     }
 

--- a/config/cdr.php
+++ b/config/cdr.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    // Maximum span of a single CDR API window query, in seconds.
+    'api_max_window_seconds' => env('CDR_API_MAX_WINDOW_SECONDS', 30 * 86400),
+
+    // Oldest date_from the API will serve, in seconds before "now".
+    'api_max_age_seconds' => env('CDR_API_MAX_AGE_SECONDS', 90 * 86400),
+
+    // Signed recording URL TTL (seconds).
+    'recording_url_ttl' => env('CDR_RECORDING_URL_TTL', 1800),
+];

--- a/config/services.php
+++ b/config/services.php
@@ -76,6 +76,14 @@ return [
         'api_key'  => env('ELEVENLABS_API_KEY', ''),
         'base_url' => env('ELEVENLABS_BASE_URL', 'https://api.elevenlabs.io'),
         'timeout'  => (int) env('ELEVENLABS_TIMEOUT', 60),
+        // Comma-separated list of public IPv4/CIDR blocks that ElevenLabs should
+        // accept inbound SIP INVITEs from. This must contain the egress IP that
+        // ElevenLabs sees on the wire — i.e. the host's public IP on bare-metal/
+        // Linode, or the NAT-egress IP if the PBX sits behind NAT.
+        'sip_allowed_addresses' => array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) env('ELEVENLABS_SIP_ALLOWED_ADDRESSES', ''))
+        ))),
     ],
 
     'keygen' => [

--- a/database/migrations/2026_04_05_000002_add_ai_agents_menu_item.php
+++ b/database/migrations/2026_04_05_000002_add_ai_agents_menu_item.php
@@ -1,0 +1,96 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Find the parent menu item that Virtual Receptionists belongs to (typically "Applications" or similar)
+        $virtualReceptionist = DB::table('v_menu_items')
+            ->where('menu_item_link', '/app/ivr_menus/ivr_menus.php')
+            ->orWhere('menu_item_title', 'IVR Menu')
+            ->orWhere('menu_item_title', 'Virtual Receptionist')
+            ->first();
+
+        $parentUuid = $virtualReceptionist?->menu_item_parent_uuid;
+        $menuUuid = $virtualReceptionist?->menu_uuid;
+
+        // If we can't find the parent, try to find any top-level menu
+        if (!$parentUuid || !$menuUuid) {
+            $menuUuid = DB::table('v_menu_items')->value('menu_uuid');
+            // Use the same parent as Ring Groups as a fallback
+            $ringGroup = DB::table('v_menu_items')
+                ->where('menu_item_title', 'Ring Groups')
+                ->orWhere('menu_item_link', '/app/ring_groups/ring_groups.php')
+                ->first();
+            $parentUuid = $ringGroup?->menu_item_parent_uuid;
+        }
+
+        if (!$menuUuid) {
+            return; // No menu system found, skip
+        }
+
+        $menuItemUuid = (string) Str::uuid();
+
+        // Check if AI Agents menu item already exists
+        $exists = DB::table('v_menu_items')
+            ->where('menu_item_title', 'AI Agents')
+            ->exists();
+
+        if ($exists) {
+            return;
+        }
+
+        // Insert the menu item
+        DB::table('v_menu_items')->insert([
+            'menu_item_uuid' => $menuItemUuid,
+            'menu_uuid' => $menuUuid,
+            'menu_item_title' => 'AI Agents',
+            'menu_item_link' => '/ai-agents',
+            'menu_item_category' => 'internal',
+            'menu_item_icon' => null,
+            'menu_item_parent_uuid' => $parentUuid,
+            'menu_item_order' => null,
+            'menu_item_description' => 'ElevenLabs Conversational AI Agents',
+            'insert_date' => now(),
+            'insert_user' => null,
+        ]);
+
+        // Grant access to superadmin and admin groups
+        $groups = DB::table('v_groups')
+            ->whereIn('group_name', ['superadmin', 'admin'])
+            ->pluck('group_uuid', 'group_name');
+
+        foreach ($groups as $groupName => $groupUuid) {
+            DB::table('v_menu_item_groups')->insert([
+                'menu_item_group_uuid' => (string) Str::uuid(),
+                'menu_uuid' => $menuUuid,
+                'menu_item_uuid' => $menuItemUuid,
+                'group_uuid' => $groupUuid,
+                'group_name' => $groupName,
+                'insert_date' => now(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        $menuItem = DB::table('v_menu_items')
+            ->where('menu_item_title', 'AI Agents')
+            ->where('menu_item_link', '/ai-agents')
+            ->first();
+
+        if ($menuItem) {
+            DB::table('v_menu_item_groups')
+                ->where('menu_item_uuid', $menuItem->menu_item_uuid)
+                ->delete();
+
+            DB::table('v_menu_items')
+                ->where('menu_item_uuid', $menuItem->menu_item_uuid)
+                ->delete();
+        }
+    }
+};

--- a/database/migrations/2026_04_05_000002_add_ai_agents_menu_item.php
+++ b/database/migrations/2026_04_05_000002_add_ai_agents_menu_item.php
@@ -8,11 +8,9 @@ return new class extends Migration
 {
     public function up(): void
     {
-        // Find the parent menu item that Virtual Receptionists belongs to (typically "Applications" or similar)
+        // Find the parent menu item that Virtual Receptionists belongs to (typically "Applications")
         $virtualReceptionist = DB::table('v_menu_items')
-            ->where('menu_item_link', '/app/ivr_menus/ivr_menus.php')
-            ->orWhere('menu_item_title', 'IVR Menu')
-            ->orWhere('menu_item_title', 'Virtual Receptionist')
+            ->where('menu_item_link', '/virtual-receptionists')
             ->first();
 
         $parentUuid = $virtualReceptionist?->menu_item_parent_uuid;
@@ -53,7 +51,7 @@ return new class extends Migration
             'menu_item_category' => 'internal',
             'menu_item_icon' => null,
             'menu_item_parent_uuid' => $parentUuid,
-            'menu_item_order' => null,
+            'menu_item_order' => 15,
             'menu_item_description' => 'ElevenLabs Conversational AI Agents',
             'insert_date' => now(),
             'insert_user' => null,

--- a/database/migrations/2026_04_07_000001_fix_ai_agents_menu_parent.php
+++ b/database/migrations/2026_04_07_000001_fix_ai_agents_menu_parent.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $vr = DB::table('v_menu_items')
+            ->where('menu_item_link', '/virtual-receptionists')
+            ->first();
+
+        if (!$vr) {
+            return;
+        }
+
+        $aiAgents = DB::table('v_menu_items')
+            ->where('menu_item_link', '/ai-agents')
+            ->first();
+
+        if (!$aiAgents) {
+            return;
+        }
+
+        if ($aiAgents->menu_item_parent_uuid === $vr->menu_item_parent_uuid
+            && $aiAgents->menu_item_order !== null) {
+            return;
+        }
+
+        DB::table('v_menu_items')
+            ->where('menu_item_uuid', $aiAgents->menu_item_uuid)
+            ->update([
+                'menu_uuid'             => $vr->menu_uuid,
+                'menu_item_parent_uuid' => $vr->menu_item_parent_uuid,
+                'menu_item_order'       => 15,
+            ]);
+
+        DB::table('v_menu_item_groups')
+            ->where('menu_item_uuid', $aiAgents->menu_item_uuid)
+            ->update(['menu_uuid' => $vr->menu_uuid]);
+    }
+
+    public function down(): void
+    {
+        // no-op: don't re-break the menu
+    }
+};

--- a/database/migrations/2026_04_07_000002_create_ai_agent_kb_documents_table.php
+++ b/database/migrations/2026_04_07_000002_create_ai_agent_kb_documents_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('v_ai_agent_kb_documents')) {
+            Schema::create('v_ai_agent_kb_documents', function (Blueprint $table) {
+                $table->uuid('kb_document_uuid')->primary()->default(DB::raw('uuid_generate_v4()'));
+                $table->uuid('ai_agent_uuid')->index();
+                $table->uuid('domain_uuid')->index();
+                $table->string('document_type', 10); // file | url | text
+                $table->string('elevenlabs_documentation_id', 255)->nullable();
+                $table->string('name', 255);
+                $table->string('file_path', 1024)->nullable();
+                $table->string('file_mime_type', 255)->nullable();
+                $table->integer('file_size')->nullable();
+                $table->string('url', 2048)->nullable();
+                $table->text('text_content')->nullable();
+                $table->string('sync_status', 20)->default('pending'); // pending | synced | failed
+                $table->text('sync_error')->nullable();
+                $table->timestamp('insert_date')->nullable();
+                $table->uuid('insert_user')->nullable();
+                $table->timestamp('update_date')->nullable();
+                $table->uuid('update_user')->nullable();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('v_ai_agent_kb_documents');
+    }
+};

--- a/database/migrations/2026_04_21_180000_fix_outbound_caller_id_dialplan_and_gateways.php
+++ b/database/migrations/2026_04_21_180000_fix_outbound_caller_id_dialplan_and_gateways.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Services\OutboundCallerIdFixer;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $result = (new OutboundCallerIdFixer())->run();
+
+        echo sprintf(
+            "[OutboundCallerIdFixer] dialplans patched: %d; gateways patched: %d\n",
+            $result['dialplans_patched'],
+            $result['gateways_patched'],
+        );
+    }
+
+    public function down(): void
+    {
+        // The forward patch converts a functionally-broken no-op into a working
+        // dialplan block; there is no meaningful rollback.
+    }
+};

--- a/database/migrations/2026_04_22_172846_add_domain_uuid_to_personal_access_tokens_table.php
+++ b/database/migrations/2026_04_22_172846_add_domain_uuid_to_personal_access_tokens_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->uuid('domain_uuid')->nullable()->after('abilities');
+            $table->index('domain_uuid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->dropIndex(['domain_uuid']);
+            $table->dropColumn('domain_uuid');
+        });
+    }
+};

--- a/database/migrations/2026_04_22_172847_add_domain_start_epoch_index_to_v_xml_cdr_table.php
+++ b/database/migrations/2026_04_22_172847_add_domain_start_epoch_index_to_v_xml_cdr_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX IF NOT EXISTS v_xml_cdr_domain_uuid_start_epoch_idx ON v_xml_cdr (domain_uuid, start_epoch DESC)');
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS v_xml_cdr_domain_uuid_start_epoch_idx');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -158,6 +158,9 @@ class DatabaseSeeder extends Seeder
             ['application_name' => 'AI Agents', 'permission_name' => 'ai_agent_add'],
             ['application_name' => 'AI Agents', 'permission_name' => 'ai_agent_edit'],
             ['application_name' => 'AI Agents', 'permission_name' => 'ai_agent_delete'],
+            ['application_name' => 'CDR API', 'permission_name' => 'cdr_api_read'],
+            ['application_name' => 'CDR API', 'permission_name' => 'cdr_api_read_all_domains'],
+            ['application_name' => 'CDR API', 'permission_name' => 'api_token_manage'],
         ];
         $timestamp = date("Y-m-d H:i:s");
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -154,6 +154,10 @@ class DatabaseSeeder extends Seeder
             ['application_name' => 'XML CDR', 'permission_name' => 'xml_cdr_search_sentiment'],
             ['application_name' => 'Messages', 'permission_name' => 'messages_view'],
             ['application_name' => 'Messages', 'permission_name' => 'messages_view_as'],
+            ['application_name' => 'AI Agents', 'permission_name' => 'ai_agent_view'],
+            ['application_name' => 'AI Agents', 'permission_name' => 'ai_agent_add'],
+            ['application_name' => 'AI Agents', 'permission_name' => 'ai_agent_edit'],
+            ['application_name' => 'AI Agents', 'permission_name' => 'ai_agent_delete'],
         ];
         $timestamp = date("Y-m-d H:i:s");
 
@@ -254,6 +258,10 @@ class DatabaseSeeder extends Seeder
                 'xml_cdr_search_sentiment',
                 'messages_view',
                 'messages_view_as',
+                'ai_agent_view',
+                'ai_agent_add',
+                'ai_agent_edit',
+                'ai_agent_delete',
             ],
             'admin' => [
                 'wakeup_calls_list_view',
@@ -285,6 +293,10 @@ class DatabaseSeeder extends Seeder
                 'extension_voicemail_settings',
                 'voicemail_message_update',
                 'xml_cdr_search_sentiment',
+                'ai_agent_view',
+                'ai_agent_add',
+                'ai_agent_edit',
+                'ai_agent_delete',
             ],
             'Message Admin' => [
                 'message_settings_list_view',

--- a/documentation/static/openapi/openapi.yaml
+++ b/documentation/static/openapi/openapi.yaml
@@ -5130,6 +5130,485 @@ paths:
         required: true
         schema:
           type: string
+  '/api/v1/domains/{domain_uuid}/cdr/calls':
+    get:
+      summary: 'List call detail records (CDRs)'
+      operationId: listCdrs
+      description: "Returns CDRs for the specified domain within a bounded date window.\n\nAccess rules:\n- Tenant token: must match the `domain_uuid` in the URL. Requests against a different domain return `forbidden_domain`.\n- Global token: may access any domain.\n- Caller must have the `cdr_api_read` permission.\n\nWindow rules:\n- `date_from` and `date_to` are required, ISO 8601 UTC.\n- The window may not exceed 30 days (`window_too_large`).\n- `date_from` must be within the last 90 days (`window_too_old`).\n\nPagination (cursor-based):\n- Default `limit` is 25, max 100. Order is by `xml_cdr_uuid`.\n- Pass `starting_after` equal to the last item's `xml_cdr_uuid` from the previous page."
+      parameters:
+        -
+          in: query
+          name: date_from
+          description: 'ISO 8601 start of window (UTC).'
+          example: '2026-04-01T00:00:00Z'
+          required: true
+          schema: { type: string }
+        -
+          in: query
+          name: date_to
+          description: 'ISO 8601 end of window (UTC).'
+          example: '2026-04-15T00:00:00Z'
+          required: true
+          schema: { type: string }
+        -
+          in: query
+          name: direction
+          description: 'inbound, outbound, or local.'
+          required: false
+          schema: { type: string, enum: [inbound, outbound, local] }
+        -
+          in: query
+          name: status
+          description: 'Normalized call status.'
+          required: false
+          schema: { type: string, enum: [answered, missed, voicemail, abandoned, busy, no_answer, failed] }
+        -
+          in: query
+          name: hangup_cause
+          description: 'FreeSWITCH hangup cause (e.g. NORMAL_CLEARING, USER_BUSY).'
+          required: false
+          schema: { type: string }
+        -
+          in: query
+          name: extension_uuid
+          required: false
+          schema: { type: string }
+        -
+          in: query
+          name: queue_uuid
+          required: false
+          schema: { type: string }
+        -
+          in: query
+          name: caller_number
+          description: 'Substring match on caller_id_number.'
+          required: false
+          schema: { type: string }
+        -
+          in: query
+          name: destination_number
+          description: 'Substring match on destination_number / caller_destination.'
+          required: false
+          schema: { type: string }
+        -
+          in: query
+          name: min_duration
+          required: false
+          schema: { type: integer }
+        -
+          in: query
+          name: max_duration
+          required: false
+          schema: { type: integer }
+        -
+          in: query
+          name: min_mos
+          description: 'Inbound RTP audio MOS floor, 1.0–5.0.'
+          required: false
+          schema: { type: number, format: float }
+        -
+          in: query
+          name: has_recording
+          required: false
+          schema: { type: boolean }
+        -
+          in: query
+          name: limit
+          description: 'Page size (1–100, default 25).'
+          required: false
+          schema: { type: integer }
+        -
+          in: query
+          name: starting_after
+          description: 'Last xml_cdr_uuid from the previous page.'
+          required: false
+          schema: { type: string }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: list
+                  url: /api/v1/domains/4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b/cdr/calls
+                  has_more: true
+                  data:
+                    -
+                      xml_cdr_uuid: 9a8b0f6e-1d83-4b9d-b2a5-7f8e1e3e9b01
+                      object: cdr_call
+                      domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                      direction: outbound
+                      status: answered
+                      caller_id_name: 'Alice Jones'
+                      caller_id_number: '+441234567890'
+                      destination_number: '+442079460000'
+                      caller_destination: null
+                      start_time: '2026-04-02T09:14:03Z'
+                      answer_time: '2026-04-02T09:14:07Z'
+                      end_time: '2026-04-02T09:17:12Z'
+                      duration: 189
+                      billsec: 185
+                      hangup_cause: NORMAL_CLEARING
+                      hangup_cause_q850: 16
+                      sip_hangup_disposition: recv_bye
+                      extension_uuid: 5bcb68c3-7c1f-4a36-a8f0-7d1d6c3b0b22
+                      queue_uuid: null
+                      mos_inbound: 4.3
+                      cost: null
+                      cost_currency: null
+                      has_recording: true
+                      recording_url: null
+                      sip_call_id: 'abc123@example.com'
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags:
+        - CDR
+    parameters:
+      -
+        in: path
+        name: domain_uuid
+        description: 'The domain UUID.'
+        example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+        required: true
+        schema: { type: string }
+  '/api/v1/domains/{domain_uuid}/cdr/calls/{xml_cdr_uuid}':
+    get:
+      summary: 'Retrieve a CDR'
+      operationId: getCdr
+      description: "Returns a single CDR including FreeSWITCH call_flow JSON, related legs, and a 30-minute signed recording URL when available.\n\nAccess rules identical to the list endpoint."
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  xml_cdr_uuid: 9a8b0f6e-1d83-4b9d-b2a5-7f8e1e3e9b01
+                  object: cdr_call
+                  domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                  direction: outbound
+                  status: answered
+                  caller_id_name: 'Alice Jones'
+                  caller_id_number: '+441234567890'
+                  destination_number: '+442079460000'
+                  start_time: '2026-04-02T09:14:03Z'
+                  answer_time: '2026-04-02T09:14:07Z'
+                  end_time: '2026-04-02T09:17:12Z'
+                  duration: 189
+                  billsec: 185
+                  hangup_cause: NORMAL_CLEARING
+                  hangup_cause_q850: 16
+                  sip_hangup_disposition: recv_bye
+                  extension_uuid: 5bcb68c3-7c1f-4a36-a8f0-7d1d6c3b0b22
+                  queue_uuid: null
+                  mos_inbound: 4.3
+                  mos_outbound: null
+                  jitter_ms: null
+                  packet_loss: null
+                  cost: null
+                  cost_currency: null
+                  has_recording: true
+                  recording_url: 'https://s3.eu-west-2.amazonaws.com/...?X-Amz-Expires=1800&...'
+                  sip_call_id: 'abc123@example.com'
+                  pdd_ms: 2140
+                  read_codec: PCMU
+                  read_rate: 8000
+                  write_codec: PCMU
+                  write_rate: 8000
+                  remote_media_ip: '203.0.113.42'
+                  network_addr: '198.51.100.17'
+                  accountcode: null
+                  call_flow: null
+                  related_legs: []
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        404: { $ref: '#/components/responses/ResourceMissing' }
+      tags:
+        - CDR
+    parameters:
+      -
+        in: path
+        name: domain_uuid
+        required: true
+        schema: { type: string }
+      -
+        in: path
+        name: xml_cdr_uuid
+        required: true
+        schema: { type: string }
+  '/api/v1/domains/{domain_uuid}/cdr/stats/summary':
+    get:
+      summary: 'CDR summary statistics'
+      operationId: cdrStatsSummary
+      description: "Aggregate counts, duration, ASR and ACD for the given domain + window. Rate-limited at 30 req/min (`cdr-stats` bucket)."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        - { $ref: '#/components/parameters/CdrDirection' }
+        - { $ref: '#/components/parameters/CdrStatus' }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: cdr_stats_summary
+                  domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                  window:
+                    from: '2026-04-01T00:00:00Z'
+                    to: '2026-04-15T00:00:00Z'
+                  totals:
+                    calls: 4821
+                    answered: 3905
+                    missed: 412
+                    voicemail: 88
+                    abandoned: 27
+                    busy: 203
+                    no_answer: 97
+                    failed: 89
+                  duration:
+                    total_sec: 892341
+                    total_billsec: 871002
+                    avg_sec: 185
+                  rates:
+                    asr: 0.902
+                    acd_sec: 223
+                  cost:
+                    total: null
+                    currency: null
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags:
+        - CDR
+    parameters:
+      -
+        in: path
+        name: domain_uuid
+        required: true
+        schema: { type: string }
+  '/api/v1/domains/{domain_uuid}/cdr/stats/by-direction':
+    get:
+      summary: 'CDR summary grouped by direction'
+      operationId: cdrStatsByDirection
+      description: "Same shape as `/stats/summary`, one row per direction value (inbound / outbound / local)."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: cdr_stats_by_direction
+                  domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                  window:
+                    from: '2026-04-01T00:00:00Z'
+                    to: '2026-04-15T00:00:00Z'
+                  data:
+                    -
+                      direction: inbound
+                      totals: { calls: 2100, answered: 1800, missed: 200, voicemail: 70, abandoned: 15, busy: 10, no_answer: 5, failed: 0 }
+                      duration: { total_sec: 410000, total_billsec: 400000, avg_sec: 195 }
+                      rates: { asr: 0.988, acd_sec: 222 }
+                      cost: { total: null, currency: null }
+                    -
+                      direction: outbound
+                      totals: { calls: 2700, answered: 2100, missed: 210, voicemail: 18, abandoned: 12, busy: 193, no_answer: 92, failed: 75 }
+                      duration: { total_sec: 480000, total_billsec: 470000, avg_sec: 178 }
+                      rates: { asr: 0.853, acd_sec: 224 }
+                      cost: { total: null, currency: null }
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags:
+        - CDR
+    parameters:
+      -
+        in: path
+        name: domain_uuid
+        required: true
+        schema: { type: string }
+  '/api/v1/domains/{domain_uuid}/cdr/stats/by-hangup-cause':
+    get:
+      summary: 'CDR breakdown by hangup cause'
+      operationId: cdrStatsByHangupCause
+      description: "Primary failure-analysis endpoint. Rows are grouped on `hangup_cause`, `hangup_cause_q850`, and `sip_hangup_disposition`, ordered by call count descending."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        - { $ref: '#/components/parameters/CdrDirection' }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: cdr_stats_by_hangup_cause
+                  domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                  window:
+                    from: '2026-04-01T00:00:00Z'
+                    to: '2026-04-15T00:00:00Z'
+                  data:
+                    -
+                      hangup_cause: NORMAL_CLEARING
+                      hangup_cause_q850: 16
+                      sip_hangup_disposition: recv_bye
+                      calls: 4205
+                      pct_of_total: 0.8722
+                      total_duration_sec: 845000
+                      total_billsec: 830000
+                      avg_duration_sec: 201
+                    -
+                      hangup_cause: USER_BUSY
+                      hangup_cause_q850: 17
+                      sip_hangup_disposition: send_refuse
+                      calls: 203
+                      pct_of_total: 0.0421
+                      total_duration_sec: 0
+                      total_billsec: 0
+                      avg_duration_sec: 0
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags:
+        - CDR
+    parameters:
+      -
+        in: path
+        name: domain_uuid
+        required: true
+        schema: { type: string }
+  /api/v1/admin/api-tokens:
+    get:
+      summary: 'List API tokens'
+      operationId: listApiTokens
+      description: "Lists all Sanctum personal access tokens. Requires the `api_token_manage` permission.\n\nTokens with a non-null `domain_uuid` are tenant-scoped; `null` means global."
+      parameters:
+        -
+          in: query
+          name: limit
+          required: false
+          schema: { type: integer }
+        -
+          in: query
+          name: starting_after
+          required: false
+          schema: { type: string }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: list
+                  url: /api/v1/admin/api-tokens
+                  has_more: false
+                  data:
+                    -
+                      object: api_token
+                      id: 0b8f1c2a-3d4e-5f67-89ab-cdef01234567
+                      name: 'Voxra dashboards'
+                      type: global
+                      domain_uuid: null
+                      abilities: [cdr:read, cdr:all-domains]
+                      last_used_at: '2026-04-22T10:01:02Z'
+                      expires_at: null
+                      created_at: '2026-04-10T08:00:00Z'
+        401: { $ref: '#/components/responses/Unauthenticated' }
+      tags:
+        - 'Admin API Tokens'
+    post:
+      summary: 'Create an API token'
+      operationId: createApiToken
+      description: "Creates a new Sanctum personal access token. Requires the `api_token_manage` permission.\n\nThe plain-text token is returned once in `token` and is unrecoverable afterwards."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, type]
+              properties:
+                name:
+                  type: string
+                  example: 'BluePeak tenant dashboard'
+                type:
+                  type: string
+                  enum: [global, tenant]
+                  example: tenant
+                domain_uuid:
+                  type: string
+                  description: 'Required when type=tenant; forbidden when type=global.'
+                  example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                expires_at:
+                  type: string
+                  description: 'Optional ISO 8601 expiry.'
+                  example: '2027-04-22T00:00:00Z'
+                abilities:
+                  type: array
+                  items: { type: string }
+                  example: [cdr:read]
+      responses:
+        201:
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: api_token
+                  id: 0b8f1c2a-3d4e-5f67-89ab-cdef01234567
+                  name: 'BluePeak tenant dashboard'
+                  type: tenant
+                  domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                  abilities: [cdr:read]
+                  expires_at: '2027-04-22T00:00:00Z'
+                  created_at: '2026-04-22T17:30:00Z'
+                  token: '1|abcdefghijklmnopqrstuvwxyz0123456789'
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags:
+        - 'Admin API Tokens'
+  '/api/v1/admin/api-tokens/{token_id}':
+    delete:
+      summary: 'Revoke an API token'
+      operationId: revokeApiToken
+      description: "Permanently deletes the token. Requires the `api_token_manage` permission."
+      responses:
+        200:
+          description: Revoked
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: api_token
+                  id: 0b8f1c2a-3d4e-5f67-89ab-cdef01234567
+                  deleted: true
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        404: { $ref: '#/components/responses/ResourceMissing' }
+      tags:
+        - 'Admin API Tokens'
+    parameters:
+      -
+        in: path
+        name: token_id
+        required: true
+        schema: { type: string }
 tags:
   -
     name: Domains
@@ -5146,12 +5625,91 @@ tags:
   -
     name: Voicemails
     description: ''
+  -
+    name: CDR
+    description: 'Call Detail Records — reporting, diagnostics, quality.'
+  -
+    name: 'Admin API Tokens'
+    description: 'Mint and revoke API tokens (internal admin only).'
 components:
   securitySchemes:
     default:
       type: http
       scheme: bearer
       description: 'You can retrieve your token by visiting your dashboard and clicking <b>Generate API token</b>.'
+  parameters:
+    CdrDateFrom:
+      in: query
+      name: date_from
+      description: 'ISO 8601 start of window (UTC). Required. Must not be older than 90 days.'
+      example: '2026-04-01T00:00:00Z'
+      required: true
+      schema: { type: string }
+    CdrDateTo:
+      in: query
+      name: date_to
+      description: 'ISO 8601 end of window (UTC). Required. Window must not exceed 30 days from date_from.'
+      example: '2026-04-15T00:00:00Z'
+      required: true
+      schema: { type: string }
+    CdrDirection:
+      in: query
+      name: direction
+      required: false
+      schema: { type: string, enum: [inbound, outbound, local] }
+    CdrStatus:
+      in: query
+      name: status
+      required: false
+      schema: { type: string, enum: [answered, missed, voicemail, abandoned, busy, no_answer, failed] }
+  responses:
+    Unauthenticated:
+      description: Unauthenticated
+      content:
+        application/json:
+          schema:
+            type: object
+            example:
+              error:
+                type: authentication_error
+                message: Unauthenticated.
+                code: unauthenticated
+    ForbiddenDomain:
+      description: 'Forbidden (token not permitted for this domain)'
+      content:
+        application/json:
+          schema:
+            type: object
+            example:
+              error:
+                type: invalid_request_error
+                message: 'This token is not permitted to access that domain.'
+                code: forbidden_domain
+                param: domain_uuid
+    WindowValidation:
+      description: 'Date window validation failure'
+      content:
+        application/json:
+          schema:
+            type: object
+            example:
+              error:
+                type: invalid_request_error
+                message: 'Window exceeds the maximum of 30 days.'
+                code: window_too_large
+                param: date_to
+    ResourceMissing:
+      description: 'Resource not found'
+      content:
+        application/json:
+          schema:
+            type: object
+            example:
+              error:
+                type: invalid_request_error
+                message: 'CDR not found.'
+                code: resource_missing
+                param: xml_cdr_uuid
 security:
   -
     default: []

--- a/resources/js/Pages/AiAgents.vue
+++ b/resources/js/Pages/AiAgents.vue
@@ -1,0 +1,391 @@
+<template>
+    <MainLayout />
+
+    <div class="m-3">
+        <DataTable @search-action="handleSearchButtonClick" @reset-filters="handleFiltersReset">
+            <template #title>AI Agents</template>
+
+            <template #filters>
+                <div class="relative min-w-64 focus-within:z-10 mb-2 sm:mr-4">
+                    <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                        <MagnifyingGlassIcon class="h-5 w-5 text-gray-400" aria-hidden="true" />
+                    </div>
+                    <input type="text" v-model="filterData.search" name="mobile-search-candidate"
+                        id="mobile-search-candidate"
+                        class="block w-full rounded-md border-0 py-1.5 pl-10 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:hidden"
+                        placeholder="Search" @keydown.enter="handleSearchButtonClick" />
+                    <input type="text" v-model="filterData.search" name="desktop-search-candidate"
+                        id="desktop-search-candidate"
+                        class="hidden w-full rounded-md border-0 py-1.5 pl-10 text-sm leading-6 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:block"
+                        placeholder="Search" @keydown.enter="handleSearchButtonClick" />
+                </div>
+            </template>
+
+            <template #action>
+                <button v-if="permissions.ai_agent_create" type="button"
+                    @click.prevent="handleCreateButtonClick()"
+                    class="rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                    Create
+                </button>
+            </template>
+
+            <template #navigation>
+                <Paginator :previous="data.prev_page_url" :next="data.next_page_url" :from="data.from" :to="data.to"
+                    :total="data.total" :currentPage="data.current_page" :lastPage="data.last_page" :links="data.links"
+                    @pagination-change-page="renderRequestedPage" :bulk-actions="bulkActions"
+                    @bulk-action="handleBulkActionRequest" :has-selected-items="selectedItems.length > 0" />
+            </template>
+            <template #table-header>
+                <TableColumnHeader
+                    class="flex whitespace-nowrap px-4 py-3.5 text-left text-sm font-semibold text-gray-900 items-center justify-start">
+                    <input type="checkbox" v-model="selectPageItems"
+                        class="h-4 w-4 rounded border-gray-300 text-indigo-600">
+                    <span class="pl-4">AI Agent</span>
+                </TableColumnHeader>
+                <TableColumnHeader header="Extension"
+                    class="px-2 py-3.5 text-left text-sm font-semibold text-gray-900" />
+                <TableColumnHeader header="Description"
+                    class="px-2 py-3.5 text-left text-sm font-semibold text-gray-900" />
+                <TableColumnHeader header="Status" class="px-2 py-3.5 text-left text-sm font-semibold text-gray-900" />
+                <TableColumnHeader header="" class="px-2 py-3.5 text-right text-sm font-semibold text-gray-900" />
+            </template>
+
+            <template v-if="selectPageItems" v-slot:current-selection>
+                <td colspan="6">
+                    <div class="text-sm text-center m-2">
+                        <span class="font-semibold ">{{ selectedItems.length }} </span> items are selected.
+                        <button v-if="!selectAll && selectedItems.length != data.total"
+                            class="text-blue-500 rounded py-2 px-2 hover:bg-blue-200  hover:text-blue-500 focus:outline-none focus:ring-1 focus:bg-blue-200 focus:ring-blue-300 transition duration-500 ease-in-out"
+                            @click="handleSelectAll">
+                            Select all {{ data.total }} items
+                        </button>
+                        <button v-if="selectAll"
+                            class="text-blue-500 rounded py-2 px-2 hover:bg-blue-200  hover:text-blue-500 focus:outline-none focus:ring-1 focus:bg-blue-200 focus:ring-blue-300 transition duration-500 ease-in-out"
+                            @click="handleClearSelection">
+                            Clear selection
+                        </button>
+                    </div>
+                </td>
+            </template>
+
+            <template #table-body>
+                <tr v-for="row in data.data" :key="row.ai_agent_uuid">
+                    <TableField class="whitespace-nowrap px-4 py-2 text-sm text-gray-500" :text="row.agent_name">
+                        <div class="flex items-center">
+                            <input v-if="row.ai_agent_uuid" v-model="selectedItems" type="checkbox" name="action_box[]"
+                                :value="row.ai_agent_uuid" class="h-4 w-4 rounded border-gray-300 text-indigo-600">
+                            <div class="ml-4"
+                                :class="{ 'cursor-pointer hover:text-gray-900': permissions.ai_agent_update, }"
+                                @click="permissions.ai_agent_update && handleEditRequest(row.ai_agent_uuid)">
+                                {{ row.agent_name }}
+                            </div>
+                        </div>
+                    </TableField>
+
+                    <TableField class="whitespace-nowrap px-2 py-2 text-sm text-gray-500"
+                        :text="row.agent_extension" />
+                    <TableField class="whitespace-nowrap px-2 py-2 text-sm text-gray-500"
+                        :text="row.description" />
+                    <TableField class="whitespace-nowrap px-2 py-2 text-sm text-gray-500" :text="row.agent_enabled">
+                        <Badge v-if="row.agent_enabled == 'true'" text="Enabled" backgroundColor="bg-green-50"
+                            textColor="text-green-700" ringColor="ring-green-600/20" />
+                        <Badge v-else text="Disabled" backgroundColor="bg-rose-50" textColor="text-rose-700"
+                            ringColor="ring-rose-600/20" />
+                    </TableField>
+
+                    <TableField class="whitespace-nowrap px-2 py-1 text-sm text-gray-500">
+                        <template #action-buttons>
+                            <div class="flex items-center whitespace-nowrap justify-end">
+                                <ejs-tooltip v-if="permissions.ai_agent_update" :content="'Edit'"
+                                    position='TopCenter' target="#destination_tooltip_target">
+                                    <div id="destination_tooltip_target">
+                                        <PencilSquareIcon @click="handleEditRequest(row.ai_agent_uuid)"
+                                            class="h-9 w-9 transition duration-500 ease-in-out py-2 rounded-full text-gray-400 hover:bg-gray-200 hover:text-gray-600 active:bg-gray-300 active:duration-150 cursor-pointer" />
+                                    </div>
+                                </ejs-tooltip>
+
+                                <ejs-tooltip v-if="permissions.ai_agent_destroy" :content="'Delete'"
+                                    position='TopCenter' target="#delete_tooltip_target">
+                                    <div id="delete_tooltip_target">
+                                        <TrashIcon @click="handleSingleItemDeleteRequest(row.ai_agent_uuid)"
+                                            class="h-9 w-9 transition duration-500 ease-in-out py-2 rounded-full text-gray-400 hover:bg-gray-200 hover:text-gray-600 active:bg-gray-300 active:duration-150 cursor-pointer" />
+                                    </div>
+                                </ejs-tooltip>
+                            </div>
+                        </template>
+                    </TableField>
+                </tr>
+            </template>
+            <template #empty>
+                <div v-if="data.data.length === 0" class="text-center my-5 ">
+                    <MagnifyingGlassIcon class="mx-auto h-12 w-12 text-gray-400" />
+                    <h3 class="mt-2 text-sm font-semibold text-gray-900">No results found</h3>
+                    <p class="mt-1 text-sm text-gray-500">
+                        Adjust your search and try again.
+                    </p>
+                </div>
+            </template>
+
+            <template #loading>
+                <Loading :show="loading" />
+            </template>
+
+            <template #footer>
+                <Paginator :previous="data.prev_page_url" :next="data.next_page_url" :from="data.from" :to="data.to"
+                    :total="data.total" :currentPage="data.current_page" :lastPage="data.last_page" :links="data.links"
+                    @pagination-change-page="renderRequestedPage" />
+            </template>
+        </DataTable>
+        <div class="px-4 sm:px-6 lg:px-8"></div>
+    </div>
+
+
+    <CreateAiAgentForm :options="itemOptions" @refresh-data="handleSearchButtonClick"
+        :show="showCreateModal" @close="showCreateModal = false" @created="handleCreatedAiAgent"
+        :loading="loadingModal" @success="showNotification" />
+
+    <UpdateAiAgentForm :options="itemOptions" @refresh-data="handleSearchButtonClick"
+        :show="showUpdateModal" @close="showUpdateModal = false"
+        :header="'Edit AI Agent - ' + itemOptions?.item?.agent_name" :loading="loadingModal"
+        @success="showNotification" />
+
+    <DeleteConfirmationModal :show="confirmationModalTrigger" @close="confirmationModalTrigger = false"
+        @confirm="confirmDeleteAction" />
+
+    <Notification :show="notificationShow" :type="notificationType" :messages="notificationMessages"
+        @update:show="hideNotification" />
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from "vue";
+import axios from 'axios';
+import DataTable from "./components/general/DataTable.vue";
+import TableColumnHeader from "./components/general/TableColumnHeader.vue";
+import TableField from "./components/general/TableField.vue";
+import Paginator from "./components/general/Paginator.vue";
+import DeleteConfirmationModal from "./components/modal/DeleteConfirmationModal.vue";
+import Loading from "./components/general/Loading.vue";
+import { registerLicense } from '@syncfusion/ej2-base';
+import { MagnifyingGlassIcon, TrashIcon, PencilSquareIcon } from "@heroicons/vue/24/solid";
+import { TooltipComponent as EjsTooltip } from "@syncfusion/ej2-vue-popups";
+import MainLayout from "../Layouts/MainLayout.vue";
+import UpdateAiAgentForm from "./components/forms/UpdateAiAgentForm.vue";
+import CreateAiAgentForm from "./components/forms/CreateAiAgentForm.vue";
+import Notification from "./components/notifications/Notification.vue";
+import Badge from "@generalComponents/Badge.vue";
+
+const loading = ref(false)
+const loadingModal = ref(false)
+const selectAll = ref(false);
+const selectedItems = ref([]);
+const showCreateModal = ref(false);
+const showUpdateModal = ref(false);
+const confirmationModalTrigger = ref(false);
+const confirmDeleteAction = ref(null);
+const notificationType = ref(null);
+const notificationMessages = ref(null);
+const notificationShow = ref(null);
+
+const props = defineProps({
+    routes: Object,
+    permissions: Object,
+});
+
+const data = ref({
+    data: [],
+    prev_page_url: null,
+    next_page_url: null,
+    from: 0,
+    to: 0,
+    total: 0,
+    current_page: 1,
+    last_page: 1,
+    links: [],
+});
+
+const filterData = ref({
+    search: null,
+});
+
+const itemOptions = ref({})
+
+onMounted(() => {
+    handleSearchButtonClick();
+})
+
+const handleSearchButtonClick = () => {
+    getData()
+};
+
+const getData = (page = 1) => {
+    loading.value = true;
+
+    axios.get(props.routes.data_route, {
+        params: {
+            filter: filterData.value,
+            page,
+        }
+    })
+        .then((response) => {
+            data.value = response.data;
+        }).catch((error) => {
+            handleErrorResponse(error);
+        }).finally(() => {
+            loading.value = false
+        })
+}
+
+const bulkActions = computed(() => {
+    const actions = [];
+    if (props.permissions.ai_agent_destroy) {
+        actions.push({
+            id: 'bulk_delete',
+            label: 'Delete',
+            icon: 'TrashIcon'
+        });
+    }
+    return actions;
+});
+
+const handleCreateButtonClick = () => {
+    showCreateModal.value = true
+    loadingModal.value = true
+    getItemOptions();
+}
+
+const handleEditRequest = (itemUuid) => {
+    showUpdateModal.value = true
+    loadingModal.value = true
+    getItemOptions(itemUuid);
+}
+
+const handleCreatedAiAgent = async (itemUuid) => {
+    showCreateModal.value = false;
+    await getData();
+    if (itemUuid) {
+        handleEditRequest(itemUuid);
+    }
+};
+
+const handleSingleItemDeleteRequest = (uuid) => {
+    confirmationModalTrigger.value = true;
+    confirmDeleteAction.value = () => executeBulkDelete([uuid]);
+}
+
+const handleBulkActionRequest = (action) => {
+    if (action === 'bulk_delete') {
+        confirmationModalTrigger.value = true;
+        confirmDeleteAction.value = () => executeBulkDelete();
+    }
+}
+
+const executeBulkDelete = (items = selectedItems.value) => {
+    axios.post(props.routes.bulk_delete, { items })
+        .then((response) => {
+            handleClearSelection();
+            handleModalClose();
+            showNotification('success', response.data.messages);
+            handleSearchButtonClick();
+        })
+        .catch((error) => {
+            handleClearSelection();
+            handleModalClose();
+            handleErrorResponse(error);
+        });
+}
+
+const handleSelectAll = () => {
+    axios.post(props.routes.select_all, filterData._rawValue)
+        .then((response) => {
+            selectedItems.value = response.data.items;
+            selectAll.value = true;
+            showNotification('success', response.data.messages);
+        }).catch((error) => {
+            handleClearSelection();
+            handleErrorResponse(error);
+        });
+};
+
+const handleFiltersReset = () => {
+    filterData.value.search = null;
+    handleClearSelection();
+    handleSearchButtonClick();
+}
+
+const renderRequestedPage = (url) => {
+    loading.value = true;
+    const urlObj = new URL(url, window.location.origin);
+    const pageParam = urlObj.searchParams.get("page") ?? 1;
+    getData(pageParam);
+};
+
+const getItemOptions = (itemUuid = null) => {
+    const payload = itemUuid ? { item_uuid: itemUuid } : {};
+
+    axios.post(props.routes.item_options, payload)
+        .then((response) => {
+            loadingModal.value = false;
+            itemOptions.value = response.data;
+        }).catch((error) => {
+            handleModalClose();
+            handleErrorResponse(error);
+        });
+}
+
+const handleErrorResponse = (error) => {
+    if (error.response) {
+        showNotification('error', error.response.data.errors || { request: [error.message] });
+    } else if (error.request) {
+        showNotification('error', { request: [error.request] });
+    } else {
+        showNotification('error', { request: [error.message] });
+    }
+}
+
+const selectPageItems = computed({
+    get() {
+        return data.value.data.length > 0 &&
+            data.value.data.every(item => selectedItems.value.includes(item.ai_agent_uuid));
+    },
+    set(value) {
+        if (value) {
+            const currentPageIds = data.value.data.map(item => item.ai_agent_uuid);
+            const newSelection = new Set([...selectedItems.value, ...currentPageIds]);
+            selectedItems.value = Array.from(newSelection);
+        } else {
+            const currentPageIds = data.value.data.map(item => item.ai_agent_uuid);
+            selectedItems.value = selectedItems.value.filter(id => !currentPageIds.includes(id));
+        }
+    }
+});
+
+const handleClearSelection = () => {
+    selectedItems.value = [],
+    selectAll.value = false;
+}
+
+const handleModalClose = () => {
+    showCreateModal.value = false;
+    showUpdateModal.value = false;
+    confirmationModalTrigger.value = false;
+}
+
+const hideNotification = () => {
+    notificationShow.value = false;
+    notificationType.value = null;
+    notificationMessages.value = null;
+}
+
+const showNotification = (type, messages = null) => {
+    notificationType.value = type;
+    notificationMessages.value = messages;
+    notificationShow.value = true;
+}
+
+registerLicense('Ngo9BigBOggjHTQxAR8/V1NAaF5cWWdCf1FpRmJGdld5fUVHYVZUTXxaS00DNHVRdkdnWX5eeHVSQ2hYUkB3WEI=');
+</script>
+
+<style>
+@import "@syncfusion/ej2-base/styles/tailwind.css";
+@import "@syncfusion/ej2-vue-popups/styles/tailwind.css";
+</style>

--- a/resources/js/Pages/components/forms/UpdateAiAgentForm.vue
+++ b/resources/js/Pages/components/forms/UpdateAiAgentForm.vue
@@ -97,6 +97,75 @@
                                     </div>
                                 </template>
                             </Vueform>
+
+                            <div v-if="!loading" class="mt-6 space-y-4 text-gray-600 bg-gray-50 px-4 py-6 sm:p-6 shadow sm:rounded-md">
+                                <div>
+                                    <h4 class="text-base font-semibold text-gray-900">Knowledge Base</h4>
+                                    <p class="text-sm text-gray-500">Upload files, add URLs, or paste text. The agent will be able to reference these in conversations.</p>
+                                </div>
+
+                                <div v-if="kbDocsList.length > 0" class="border border-gray-200 rounded-md divide-y divide-gray-200 bg-white">
+                                    <div v-for="doc in kbDocsList" :key="doc.kb_document_uuid"
+                                        class="flex items-center justify-between px-3 py-2 text-sm">
+                                        <div class="flex items-center space-x-3 min-w-0">
+                                            <span class="inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ring-1 ring-inset"
+                                                :class="{
+                                                    'bg-blue-50 text-blue-700 ring-blue-700/10': doc.document_type === 'file',
+                                                    'bg-green-50 text-green-700 ring-green-700/10': doc.document_type === 'url',
+                                                    'bg-amber-50 text-amber-700 ring-amber-700/10': doc.document_type === 'text',
+                                                }">{{ doc.document_type }}</span>
+                                            <div class="min-w-0">
+                                                <div class="font-medium text-gray-900 truncate">{{ doc.name }}</div>
+                                                <div v-if="doc.url" class="text-xs text-gray-500 truncate">{{ doc.url }}</div>
+                                                <div v-else-if="doc.file_size" class="text-xs text-gray-500">{{ formatBytes(doc.file_size) }}</div>
+                                            </div>
+                                        </div>
+                                        <button type="button" @click="deleteKbDoc(doc)"
+                                            class="ml-3 text-rose-600 hover:text-rose-800 disabled:opacity-50"
+                                            :disabled="kbBusy">
+                                            <TrashIcon class="h-5 w-5" />
+                                        </button>
+                                    </div>
+                                </div>
+                                <div v-else class="text-sm text-gray-500 italic">No knowledge base documents yet.</div>
+
+                                <div class="border-t border-gray-200 pt-4">
+                                    <div class="flex space-x-2 mb-3">
+                                        <button type="button" v-for="t in ['file','url','text']" :key="t"
+                                            @click="kbType = t"
+                                            class="px-3 py-1 text-sm rounded-md ring-1 ring-inset"
+                                            :class="kbType === t ? 'bg-indigo-600 text-white ring-indigo-600' : 'bg-white text-gray-700 ring-gray-300 hover:bg-gray-50'">
+                                            {{ t === 'file' ? 'Upload file' : t === 'url' ? 'Add URL' : 'Add text' }}
+                                        </button>
+                                    </div>
+
+                                    <div class="space-y-2">
+                                        <input type="text" v-model="kbName" placeholder="Display name"
+                                            class="block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm" />
+
+                                        <input v-if="kbType === 'file'" type="file" ref="kbFileInput"
+                                            accept=".pdf,.txt,.docx,.html,.htm,.epub,.md"
+                                            class="block w-full text-sm text-gray-700 file:mr-3 file:rounded-md file:border-0 file:bg-indigo-50 file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-indigo-700 hover:file:bg-indigo-100" />
+
+                                        <input v-if="kbType === 'url'" type="url" v-model="kbUrl"
+                                            placeholder="https://example.com/help.html"
+                                            class="block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm" />
+
+                                        <textarea v-if="kbType === 'text'" v-model="kbText" rows="4"
+                                            placeholder="Paste the text snippet the agent should know about..."
+                                            class="block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm" />
+
+                                        <div v-if="kbError" class="text-sm text-rose-600">{{ kbError }}</div>
+
+                                        <div class="flex justify-end">
+                                            <button type="button" @click="addKbDoc" :disabled="kbBusy"
+                                                class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50">
+                                                {{ kbBusy ? 'Adding…' : 'Add to knowledge base' }}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </DialogPanel>
                     </TransitionChild>
                 </div>
@@ -106,9 +175,10 @@
 </template>
 
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
+import axios from "axios";
 import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue'
-import { XMarkIcon } from "@heroicons/vue/24/solid";
+import { XMarkIcon, TrashIcon } from "@heroicons/vue/24/solid";
 
 const props = defineProps({
     show: Boolean,
@@ -208,5 +278,103 @@ const handleError = (error, details, form$) => {
 
 const handleClose = () => {
     emit('close');
+};
+
+// ----- Knowledge Base -----
+const kbDocsList = ref([]);
+const kbType = ref('file');
+const kbName = ref('');
+const kbUrl = ref('');
+const kbText = ref('');
+const kbFileInput = ref(null);
+const kbBusy = ref(false);
+const kbError = ref(null);
+
+watch(() => props.options?.kb_documents, (docs) => {
+    kbDocsList.value = Array.isArray(docs) ? [...docs] : [];
+}, { immediate: true });
+
+const formatBytes = (bytes) => {
+    if (!bytes) return '';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let i = 0;
+    let n = bytes;
+    while (n >= 1024 && i < units.length - 1) { n /= 1024; i++; }
+    return n.toFixed(n >= 10 || i === 0 ? 0 : 1) + ' ' + units[i];
+};
+
+const addKbDoc = async () => {
+    kbError.value = null;
+
+    if (!kbName.value.trim()) {
+        kbError.value = 'Please enter a display name.';
+        return;
+    }
+
+    const storeRoute = props.options?.routes?.kb_store_route;
+    if (!storeRoute) {
+        kbError.value = 'Knowledge base endpoint not available.';
+        return;
+    }
+
+    const fd = new FormData();
+    fd.append('document_type', kbType.value);
+    fd.append('name', kbName.value);
+
+    if (kbType.value === 'file') {
+        const file = kbFileInput.value?.files?.[0];
+        if (!file) {
+            kbError.value = 'Please choose a file.';
+            return;
+        }
+        fd.append('file', file);
+    } else if (kbType.value === 'url') {
+        if (!kbUrl.value.trim()) {
+            kbError.value = 'Please enter a URL.';
+            return;
+        }
+        fd.append('url', kbUrl.value);
+    } else {
+        if (!kbText.value.trim()) {
+            kbError.value = 'Please enter some text.';
+            return;
+        }
+        fd.append('text', kbText.value);
+    }
+
+    kbBusy.value = true;
+    try {
+        const res = await axios.post(storeRoute, fd, {
+            headers: { 'Content-Type': 'multipart/form-data' },
+        });
+        kbDocsList.value.unshift(res.data.kb_document);
+        kbName.value = '';
+        kbUrl.value = '';
+        kbText.value = '';
+        if (kbFileInput.value) kbFileInput.value.value = '';
+        emit('success', 'success', res.data.messages);
+    } catch (err) {
+        const msg = err.response?.data?.errors?.server?.[0]
+            || err.response?.data?.message
+            || err.message
+            || 'Failed to add knowledge base document.';
+        kbError.value = msg;
+    } finally {
+        kbBusy.value = false;
+    }
+};
+
+const deleteKbDoc = async (doc) => {
+    if (!confirm('Remove "' + doc.name + '" from the knowledge base?')) return;
+    kbBusy.value = true;
+    try {
+        await axios.delete(doc.delete_route);
+        kbDocsList.value = kbDocsList.value.filter(d => d.kb_document_uuid !== doc.kb_document_uuid);
+        emit('success', 'success', { success: ['Knowledge base document removed.'] });
+    } catch (err) {
+        emit('error', err);
+    } finally {
+        kbBusy.value = false;
+    }
 };
 </script>

--- a/resources/lua/push_wake.lua
+++ b/resources/lua/push_wake.lua
@@ -1,0 +1,116 @@
+-- push_wake.lua
+--
+-- Fires the APNs VoIP push for an incoming call to a push-enabled extension
+-- and waits briefly for the device to re-REGISTER, so local_extension can
+-- bridge to it when the iOS app is backgrounded/closed.
+--
+-- Invoked from the FreeSWITCH dialplan as an early `continue="true"` extension
+-- (order < local_extension) so this script runs before the user lookup tries
+-- to bridge. If the extension has no apns_voip_token the script returns a
+-- no-op and normal dialplan flow is unchanged.
+--
+-- Flow:
+--   1. Resolve extension_uuid and apns_voip_token via user_data API.
+--   2. If no token, return — this is a regular SIP phone; nothing to do.
+--   3. Fire-and-forget HTTP POST to voxra webhook with event=incoming_call,
+--      which triggers SendIncomingCallPushJob → ApnsPushService.
+--   4. pre_answer the inbound leg so the caller hears early media (ringback)
+--      while we wait for the phone to wake and re-register.
+--   5. Poll sofia_contact every 500ms for up to PUSH_WAKE_TIMEOUT_MS; return
+--      as soon as a contact appears (local_extension bridge will succeed),
+--      or at timeout (falls through to forward_user_not_registered).
+
+local SCRIPT_NAME = "[push_wake.lua]"
+local WEBHOOK_URL = "http://127.0.0.1/webhook/freeswitch"
+local WEBHOOK_SECRET = "tH0FXyxfG6Kh36*VHYdE4G!gwfE3Pf"
+local PUSH_WAKE_TIMEOUT_MS = 15000
+local PUSH_WAKE_POLL_MS = 500
+
+local json = require "resources.functions.lunajson"
+local api = freeswitch.API()
+
+local function log(level, msg)
+    freeswitch.consoleLog(level, SCRIPT_NAME .. " " .. tostring(msg) .. "\n")
+end
+
+local function api_value(cmd)
+    local v = api:executeString(cmd)
+    if not v then return "" end
+    v = v:gsub("%s+$", "")
+    if v == "" or v:match("^%-ERR") or v == "_undef_" then return "" end
+    return v
+end
+
+local function shell_quote(s)
+    return "'" .. tostring(s or ""):gsub("'", "'\\''") .. "'"
+end
+
+if not session or not session:ready() then
+    return
+end
+
+local destination_number = session:getVariable("destination_number") or ""
+local domain_name = session:getVariable("domain_name") or ""
+local caller_id_name = session:getVariable("caller_id_name") or "Unknown"
+local caller_id_number = session:getVariable("caller_id_number") or ""
+local call_uuid = session:getVariable("uuid") or ""
+
+if destination_number == "" or domain_name == "" then
+    return
+end
+
+local aor = destination_number .. "@" .. domain_name
+
+local apns_token = api_value("user_data " .. aor .. " var apns_voip_token")
+if apns_token == "" then
+    return
+end
+
+local extension_uuid = api_value("user_data " .. aor .. " attr id")
+
+local payload = json.encode({
+    event = "incoming_call",
+    timestamp = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+    data = {
+        extension_uuid = extension_uuid,
+        extension_number = destination_number,
+        domain_name = domain_name,
+        caller_id_name = caller_id_name,
+        caller_id_number = caller_id_number,
+        call_uuid = call_uuid,
+    },
+})
+
+local hmac_cmd = string.format(
+    "printf %%s %s | openssl dgst -sha256 -hmac %s | awk '{print $NF}'",
+    shell_quote(payload), shell_quote(WEBHOOK_SECRET)
+)
+local hmac_handle = io.popen(hmac_cmd)
+local signature = hmac_handle and hmac_handle:read("*a") or ""
+if hmac_handle then hmac_handle:close() end
+signature = signature:gsub("%s+", "")
+
+local curl_cmd = string.format(
+    "(curl -k -s -m 5 -X POST -H 'Content-Type: application/json' -H 'Signature: %s' -d %s %s >/dev/null 2>&1) &",
+    signature, shell_quote(payload), shell_quote(WEBHOOK_URL)
+)
+os.execute(curl_cmd)
+log("INFO", "dispatched incoming_call webhook for " .. aor)
+
+if not session:ready() then return end
+session:preAnswer()
+
+local deadline_attempts = math.floor(PUSH_WAKE_TIMEOUT_MS / PUSH_WAKE_POLL_MS)
+local attempt = 0
+while attempt < deadline_attempts do
+    if not session:ready() then return end
+    local contact = api_value("sofia_contact */" .. aor)
+    if contact ~= "" then
+        log("INFO", string.format("registered after %dms — handing off to local_extension", attempt * PUSH_WAKE_POLL_MS))
+        return
+    end
+    session:sleep(PUSH_WAKE_POLL_MS)
+    attempt = attempt + 1
+end
+
+log("NOTICE", "push_wake timeout for " .. aor .. " — falling through to forward_user_not_registered")

--- a/resources/views/layouts/xml/ai-agent-dial-plan-template.blade.php
+++ b/resources/views/layouts/xml/ai-agent-dial-plan-template.blade.php
@@ -6,6 +6,6 @@
         <action application="set" data="hangup_after_bridge=true" />
         <action application="set" data="absolute_codec_string=PCMU,PCMA" />
         <action application="set" data="ai_agent_uuid={{ $agent->ai_agent_uuid }}" />
-        <action application="bridge" data="sofia/external/sip:{{ $agent->agent_extension }}@sip.rtc.elevenlabs.io:5060" />
+        <action application="bridge" data="sofia/external/sip:{{ $agent->agent_extension }}@sip.rtc.elevenlabs.io:5060;transport=tcp" />
     </condition>
 </extension>

--- a/resources/views/layouts/xml/ai-agent-dial-plan-template.blade.php
+++ b/resources/views/layouts/xml/ai-agent-dial-plan-template.blade.php
@@ -5,6 +5,9 @@
         <action application="sleep" data="1000" />
         <action application="set" data="hangup_after_bridge=true" />
         <action application="set" data="absolute_codec_string=PCMU,PCMA" />
+        <action application="set" data="ringback=$${uk-ring}" />
+        <action application="set" data="transfer_ringback=$${uk-ring}" />
+        <action application="set" data="ignore_early_media=true" />
         <action application="set" data="ai_agent_uuid={{ $agent->ai_agent_uuid }}" />
         <action application="bridge" data="sofia/external/sip:{{ $agent->agent_extension }}@sip.rtc.elevenlabs.io:5060;transport=tcp" />
     </condition>

--- a/routes/api.php
+++ b/routes/api.php
@@ -229,6 +229,8 @@ Route::group(['middleware' => ['auth:sanctum', 'api.cookie.auth']], function () 
     Route::post('ai-agents/item-options', [AiAgentController::class, 'getItemOptions'])->name('ai-agents.item.options');
     Route::post('ai-agents/bulk-delete', [AiAgentController::class, 'bulkDelete'])->name('ai-agents.bulk.delete');
     Route::post('ai-agents/select-all', [AiAgentController::class, 'selectAll'])->name('ai-agents.select.all');
+    Route::post('ai-agents/{ai_agent}/kb-documents', [AiAgentController::class, 'storeKbDocument'])->name('ai-agents.kb.store');
+    Route::delete('ai-agents/{ai_agent}/kb-documents/{kb_document}', [AiAgentController::class, 'deleteKbDocument'])->name('ai-agents.kb.delete');
 
     // Virtual Receptionist
     Route::post('virtual-receptionists', [VirtualReceptionistController::class, 'store'])->name('virtual-receptionists.store');

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\V1\RingGroupController;
 use App\Http\Controllers\Api\V1\VoicemailController;
 use App\Http\Controllers\Api\V1\PhoneNumberController;
 use App\Http\Controllers\Api\V1\UserController;
+use App\Http\Controllers\Api\V1\AiAgentController;
 
 /*
 |--------------------------------------------------------------------------
@@ -137,4 +138,15 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
     Route::delete('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'destroy'])
         ->middleware('user.authorize:user_delete')->name('api.v1.users.destroy');
+
+    /*
+    |--------------------------------------------------------------------------
+    | AI Agents (domain-scoped, read-only)
+    |--------------------------------------------------------------------------
+    */
+    Route::get('/domains/{domain_uuid}/ai-agents', [AiAgentController::class, 'index'])
+        ->middleware('user.authorize:ai_agent_view')->name('api.v1.ai-agents.index');
+
+    Route::get('/domains/{domain_uuid}/ai-agents/{ai_agent_uuid}', [AiAgentController::class, 'show'])
+        ->middleware('user.authorize:ai_agent_view')->name('api.v1.ai-agents.show');
 });

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -8,6 +8,9 @@ use App\Http\Controllers\Api\V1\VoicemailController;
 use App\Http\Controllers\Api\V1\PhoneNumberController;
 use App\Http\Controllers\Api\V1\UserController;
 use App\Http\Controllers\Api\V1\AiAgentController;
+use App\Http\Controllers\Api\V1\CdrCallController;
+use App\Http\Controllers\Api\V1\CdrStatsController;
+use App\Http\Controllers\Api\V1\Admin\ApiTokenController;
 
 /*
 |--------------------------------------------------------------------------
@@ -149,4 +152,47 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
     Route::get('/domains/{domain_uuid}/ai-agents/{ai_agent_uuid}', [AiAgentController::class, 'show'])
         ->middleware('user.authorize:ai_agent_view')->name('api.v1.ai-agents.show');
+
+    /*
+    |--------------------------------------------------------------------------
+    | CDR (Call Detail Records) — domain-scoped, read-only
+    |--------------------------------------------------------------------------
+    | All routes enforce tenant-vs-global token scope via `cdr.scope`. Stats
+    | endpoints use a stricter rate limiter.
+    */
+    Route::middleware(['cdr.scope:tenant', 'user.authorize:cdr_api_read'])->group(function () {
+        Route::get('/domains/{domain_uuid}/cdr/calls', [CdrCallController::class, 'index'])
+            ->name('api.v1.cdr.calls.index');
+
+        Route::get('/domains/{domain_uuid}/cdr/calls/{xml_cdr_uuid}', [CdrCallController::class, 'show'])
+            ->name('api.v1.cdr.calls.show');
+
+        Route::middleware('throttle:cdr-stats')->group(function () {
+            Route::get('/domains/{domain_uuid}/cdr/stats/summary', [CdrStatsController::class, 'summary'])
+                ->name('api.v1.cdr.stats.summary');
+
+            Route::get('/domains/{domain_uuid}/cdr/stats/by-direction', [CdrStatsController::class, 'byDirection'])
+                ->name('api.v1.cdr.stats.by-direction');
+
+            Route::get('/domains/{domain_uuid}/cdr/stats/by-hangup-cause', [CdrStatsController::class, 'byHangupCause'])
+                ->name('api.v1.cdr.stats.by-hangup-cause');
+        });
+    });
+
+    /*
+    |--------------------------------------------------------------------------
+    | Admin — API token management
+    |--------------------------------------------------------------------------
+    | Tokens are minted by an internal admin. Tenant self-service is deferred.
+    */
+    Route::middleware('user.authorize:api_token_manage')->group(function () {
+        Route::get('/admin/api-tokens', [ApiTokenController::class, 'index'])
+            ->name('api.v1.admin.api-tokens.index');
+
+        Route::post('/admin/api-tokens', [ApiTokenController::class, 'store'])
+            ->name('api.v1.admin.api-tokens.store');
+
+        Route::delete('/admin/api-tokens/{token_id}', [ApiTokenController::class, 'destroy'])
+            ->name('api.v1.admin.api-tokens.destroy');
+    });
 });

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\V1\ExtensionController;
 use App\Http\Controllers\Api\V1\RingGroupController;
 use App\Http\Controllers\Api\V1\VoicemailController;
 use App\Http\Controllers\Api\V1\PhoneNumberController;
+use App\Http\Controllers\Api\V1\UserController;
 
 /*
 |--------------------------------------------------------------------------
@@ -116,4 +117,24 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
     Route::delete('/domains/{domain_uuid}/phone-numbers/{destination_uuid}', [PhoneNumberController::class, 'destroy'])
         ->middleware('user.authorize:ring_group_delete');
+
+    /*
+    |--------------------------------------------------------------------------
+    | Users (domain-scoped)
+    |--------------------------------------------------------------------------
+    */
+    Route::get('/domains/{domain_uuid}/users', [UserController::class, 'index'])
+        ->middleware('user.authorize:user_view')->name('api.v1.users.index');
+
+    Route::get('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'show'])
+        ->middleware('user.authorize:user_view')->name('api.v1.users.show');
+
+    Route::post('/domains/{domain_uuid}/users', [UserController::class, 'store'])
+        ->middleware('user.authorize:user_add')->name('api.v1.users.store');
+
+    Route::patch('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'update'])
+        ->middleware('user.authorize:user_edit')->name('api.v1.users.update');
+
+    Route::delete('/domains/{domain_uuid}/users/{user_uuid}', [UserController::class, 'destroy'])
+        ->middleware('user.authorize:user_delete')->name('api.v1.users.destroy');
 });

--- a/tests/Feature/Api/V1/Cdr/CdrRouteProtectionTest.php
+++ b/tests/Feature/Api/V1/Cdr/CdrRouteProtectionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Api\V1\Cdr;
+
+use Tests\TestCase;
+
+/**
+ * Route-level protection smoke tests.
+ *
+ * These assert the middleware chain rejects unauthenticated / unbearered
+ * requests before ever reaching the controller. Full domain-scoping behaviour
+ * is covered by tests/Unit/Cdr/* and will be tested end-to-end once fixture
+ * infrastructure exists.
+ */
+class CdrRouteProtectionTest extends TestCase
+{
+    private const DOMAIN = '00000000-0000-0000-0000-000000000001';
+
+    public function test_list_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/cdr/calls')
+            ->assertStatus(401);
+    }
+
+    public function test_summary_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/cdr/stats/summary')
+            ->assertStatus(401);
+    }
+
+    public function test_show_requires_authentication(): void
+    {
+        $uuid = '00000000-0000-0000-0000-000000000002';
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/cdr/calls/' . $uuid)
+            ->assertStatus(401);
+    }
+
+    public function test_admin_token_list_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/admin/api-tokens')
+            ->assertStatus(401);
+    }
+
+    public function test_admin_token_create_requires_authentication(): void
+    {
+        $this->postJson('/api/v1/admin/api-tokens', [
+            'name' => 'test',
+            'type' => 'global',
+        ])->assertStatus(401);
+    }
+}

--- a/tests/Unit/Cdr/CallStatusResolverTest.php
+++ b/tests/Unit/Cdr/CallStatusResolverTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Unit\Cdr;
+
+use App\Enums\Cdr\CallStatus;
+use App\Services\Cdr\CallStatusResolver;
+use Tests\TestCase;
+use stdClass;
+
+class CallStatusResolverTest extends TestCase
+{
+    private CallStatusResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new CallStatusResolver();
+    }
+
+    public function test_voicemail_takes_precedence(): void
+    {
+        $cdr = $this->cdr([
+            'voicemail_message' => true,
+            'missed_call' => true,
+            'hangup_cause' => 'NORMAL_CLEARING',
+        ]);
+
+        $this->assertSame(CallStatus::Voicemail, $this->resolver->resolve($cdr));
+    }
+
+    public function test_abandoned_requires_break_out_cancel(): void
+    {
+        $cdr = $this->cdr([
+            'missed_call' => true,
+            'hangup_cause' => 'NORMAL_CLEARING',
+            'cc_cancel_reason' => 'BREAK_OUT',
+            'cc_cause' => 'cancel',
+        ]);
+
+        $this->assertSame(CallStatus::Abandoned, $this->resolver->resolve($cdr));
+    }
+
+    public function test_missed_call_without_abandon_signals_is_missed(): void
+    {
+        $cdr = $this->cdr([
+            'missed_call' => true,
+            'hangup_cause' => 'NORMAL_CLEARING',
+        ]);
+
+        $this->assertSame(CallStatus::Missed, $this->resolver->resolve($cdr));
+    }
+
+    public function test_user_busy_is_busy(): void
+    {
+        $cdr = $this->cdr([
+            'hangup_cause' => 'USER_BUSY',
+        ]);
+
+        $this->assertSame(CallStatus::Busy, $this->resolver->resolve($cdr));
+    }
+
+    public function test_no_answer_hangup_causes_map_to_no_answer(): void
+    {
+        foreach (['NO_ANSWER', 'NO_USER_RESPONSE', 'ALLOTTED_TIMEOUT'] as $cause) {
+            $cdr = $this->cdr(['hangup_cause' => $cause]);
+            $this->assertSame(
+                CallStatus::NoAnswer,
+                $this->resolver->resolve($cdr),
+                "Expected NoAnswer for hangup_cause={$cause}"
+            );
+        }
+    }
+
+    public function test_answered_call_is_answered(): void
+    {
+        $cdr = $this->cdr([
+            'answer_epoch' => 1712048047,
+            'hangup_cause' => 'NORMAL_CLEARING',
+        ]);
+
+        $this->assertSame(CallStatus::Answered, $this->resolver->resolve($cdr));
+    }
+
+    public function test_unanswered_with_unknown_cause_is_failed(): void
+    {
+        $cdr = $this->cdr([
+            'answer_epoch' => 0,
+            'hangup_cause' => 'RECOVERY_ON_TIMER_EXPIRE',
+        ]);
+
+        $this->assertSame(CallStatus::Failed, $this->resolver->resolve($cdr));
+    }
+
+    private function cdr(array $fields): stdClass
+    {
+        $defaults = [
+            'voicemail_message' => false,
+            'missed_call' => false,
+            'hangup_cause' => null,
+            'cc_cancel_reason' => null,
+            'cc_cause' => null,
+            'answer_epoch' => 0,
+        ];
+
+        $row = new stdClass();
+        foreach (array_merge($defaults, $fields) as $k => $v) {
+            $row->{$k} = $v;
+        }
+        return $row;
+    }
+}

--- a/tests/Unit/Cdr/CdrApiFilterParserTest.php
+++ b/tests/Unit/Cdr/CdrApiFilterParserTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Unit\Cdr;
+
+use App\Enums\Cdr\CallDirection;
+use App\Enums\Cdr\CallStatus;
+use App\Exceptions\ApiException;
+use App\Services\Cdr\CdrApiFilterParser;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class CdrApiFilterParserTest extends TestCase
+{
+    private CdrApiFilterParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new CdrApiFilterParser();
+    }
+
+    public function test_missing_dates_raises_parameter_missing(): void
+    {
+        $this->expectApi('parameter_missing', 'date_from', 422, function () {
+            $this->parser->fromRequest($this->req([]));
+        });
+    }
+
+    public function test_invalid_iso_dates_raise_invalid_request(): void
+    {
+        $this->expectApi('invalid_request', 'date_from', 422, function () {
+            $this->parser->fromRequest($this->req([
+                'date_from' => 'not-a-date',
+                'date_to' => '2026-04-10T00:00:00Z',
+            ]));
+        });
+    }
+
+    public function test_inverted_range_raises(): void
+    {
+        $this->expectApi('invalid_request', 'date_to', 422, function () {
+            $this->parser->fromRequest($this->req([
+                'date_from' => '2026-04-10T00:00:00Z',
+                'date_to' => '2026-04-01T00:00:00Z',
+            ]));
+        });
+    }
+
+    public function test_oversize_window_raises_window_too_large(): void
+    {
+        $this->expectApi('window_too_large', 'date_to', 422, function () {
+            $this->parser->fromRequest($this->req([
+                'date_from' => '2026-01-01T00:00:00Z',
+                'date_to' => '2026-04-01T00:00:00Z', // ~90 days
+            ]));
+        });
+    }
+
+    public function test_oversize_age_raises_window_too_old(): void
+    {
+        $this->expectApi('window_too_old', 'date_from', 422, function () {
+            $this->parser->fromRequest($this->req([
+                // 2 years ago — blown past the 90-day retention cap
+                'date_from' => gmdate('Y-m-d\TH:i:s\Z', time() - (365 * 2 * 86400)),
+                'date_to' => gmdate('Y-m-d\TH:i:s\Z', time() - (365 * 2 * 86400) + 86400),
+            ]));
+        });
+    }
+
+    public function test_valid_window_and_filters_parse(): void
+    {
+        $fromIso = gmdate('Y-m-d\TH:i:s\Z', time() - 86400 * 7);
+        $toIso = gmdate('Y-m-d\TH:i:s\Z', time() - 86400);
+
+        $filters = $this->parser->fromRequest($this->req([
+            'date_from' => $fromIso,
+            'date_to' => $toIso,
+            'direction' => 'outbound',
+            'status' => 'answered',
+            'min_mos' => '3.5',
+            'has_recording' => 'true',
+            'caller_number' => '+44123',
+        ]));
+
+        $this->assertSame(CallDirection::Outbound, $filters->direction);
+        $this->assertSame(CallStatus::Answered, $filters->status);
+        $this->assertSame(3.5, $filters->minMos);
+        $this->assertSame(true, $filters->hasRecording);
+        $this->assertSame('+44123', $filters->callerNumber);
+    }
+
+    public function test_unknown_direction_raises(): void
+    {
+        $fromIso = gmdate('Y-m-d\TH:i:s\Z', time() - 86400 * 2);
+        $toIso = gmdate('Y-m-d\TH:i:s\Z', time() - 86400);
+
+        $this->expectApi('invalid_request', 'direction', 422, function () use ($fromIso, $toIso) {
+            $this->parser->fromRequest($this->req([
+                'date_from' => $fromIso,
+                'date_to' => $toIso,
+                'direction' => 'diagonal',
+            ]));
+        });
+    }
+
+    private function req(array $query): Request
+    {
+        return Request::create('/test', 'GET', $query);
+    }
+
+    private function expectApi(string $code, ?string $param, int $status, callable $fn): void
+    {
+        try {
+            $fn();
+            $this->fail("Expected ApiException with code={$code} to be thrown.");
+        } catch (ApiException $e) {
+            $this->assertSame($status, $e->status);
+            $this->assertSame($code, $e->error_code);
+            if ($param !== null) {
+                $this->assertSame($param, $e->param);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Exposes FreeSWITCH Call Detail Records via a v1 REST API. Two token types:
- **Tenant tokens** — bound to a single `domain_uuid`; scoped to URL path
- **Global admin tokens** — can query any domain for internal diagnostics

Matches the existing v1 API conventions (nested under `/api/v1/domains/{domain_uuid}/…`, Stripe-style envelope, cursor pagination via `starting_after`).

## Endpoints

**Tenant-scoped CDR (read-only)**
- `GET /api/v1/domains/{uuid}/cdr/calls` — paginated list with filters
- `GET /api/v1/domains/{uuid}/cdr/calls/{xml_cdr_uuid}` — detail incl. call_flow + signed recording URL
- `GET /api/v1/domains/{uuid}/cdr/stats/summary` — totals, ASR, ACD
- `GET /api/v1/domains/{uuid}/cdr/stats/by-direction`
- `GET /api/v1/domains/{uuid}/cdr/stats/by-hangup-cause` — primary failure-analysis endpoint

**Admin token management**
- `POST/GET /api/v1/admin/api-tokens`, `DELETE /api/v1/admin/api-tokens/{id}`

## Key design decisions

- New `domain_uuid` column on `personal_access_tokens`; `ResolveCdrScope` middleware enforces tenant-vs-global
- 30-day max window, 90-day retention cap (configurable via `config/cdr.php`)
- Signed S3/local recording URLs via existing `CallRecordingUrlService` (30-min TTL)
- Single `CallStatusResolver` used by both API and Vue UI
- `throttle:cdr-stats` (30/min) on aggregate endpoints
- Composite index on `v_xml_cdr(domain_uuid, start_epoch DESC)`
- New permissions: `cdr_api_read`, `cdr_api_read_all_domains`, `api_token_manage`

## Quality caveat

Only `rtp_audio_in_mos` is captured today. `mos_outbound`, `jitter_ms`, `packet_loss` are exposed as `null` pending FreeSWITCH CDR template changes. `cost`/`cost_currency` are `null` pending a rating engine.

## What's in the follow-up PR

- Remaining stats endpoints: `by-extension`, `timeseries`, `quality`, `top-destinations`
- Global admin routes (`/api/v1/cdr/calls?domain_uuid=…`, `scope=global`)

## Test plan

- [x] `php -l` clean on all 22 files (PHP 8.4.19 on primary)
- [x] `php artisan config:cache` and `route:cache` succeed (all DI resolves)
- [x] 8 new routes register with correct middleware stacks
- [x] Migrations dry-run shows expected SQL; `IF NOT EXISTS` on index
- [x] 14 unit tests + 5 feature tests passing on voxra-pbx-lon1
- [ ] Deploy to voxra-pbx-lon1 via `ansible-playbook voxra.yml --tags fspbx`
- [ ] Run `php artisan db:seed --class=DatabaseSeeder` to add the 3 new permissions
- [ ] Mint an admin token, curl-smoke the endpoints
- [ ] Run `ExampleTest` regression check (it fails pre-existing; not caused by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)