### PR TITLE
CDR tenant self-service API tokens

### DIFF
--- a/app/Http/Controllers/Api/V1/TenantApiTokenController.php
+++ b/app/Http/Controllers/Api/V1/TenantApiTokenController.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use App\Models\Domain;
+use App\Models\Sanctum\PersonalAccessToken;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+/**
+ * Tenant self-service API token management.
+ *
+ * Reachable only via `cdr.scope:tenant` routes — the middleware guarantees
+ * the token operating on these endpoints is bound to the URL's
+ * `{domain_uuid}`. All token operations are further scoped to that domain
+ * to prevent a tenant viewing or mutating another tenant's tokens.
+ */
+class TenantApiTokenController extends Controller
+{
+    /**
+     * List tokens for this tenant.
+     *
+     * @group Tenant API Tokens
+     * @authenticated
+     */
+    public function index(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid);
+
+        $limit = max(1, min(100, (int) $request->query('limit', 25)));
+        $startingAfter = trim((string) $request->query('starting_after', ''));
+
+        $query = PersonalAccessToken::query()
+            ->where('domain_uuid', $domain_uuid)
+            ->orderBy('id');
+
+        if ($startingAfter !== '') {
+            $query->where('id', '>', $startingAfter);
+        }
+
+        $rows = $query->limit($limit + 1)->get();
+        $hasMore = $rows->count() > $limit;
+        $rows = $rows->take($limit);
+
+        return response()->json([
+            'object' => 'list',
+            'url' => '/api/v1/domains/' . $domain_uuid . '/api-tokens',
+            'has_more' => $hasMore,
+            'data' => $rows->map(fn ($t) => $this->summarize($t))->all(),
+        ], 200);
+    }
+
+    /**
+     * Create a tenant-scoped API token.
+     *
+     * Body: { name: string, expires_at?: ISO8601, abilities?: string[] }
+     *
+     * Tenant tokens are always bound to the domain in the URL — callers
+     * cannot override that via the body.
+     *
+     * @group Tenant API Tokens
+     * @authenticated
+     */
+    public function store(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid);
+
+        $user = $request->user();
+        if (! $user) {
+            throw new ApiException(401, 'authentication_error', 'Unauthenticated.', 'unauthenticated');
+        }
+
+        $name = trim((string) $request->input('name', ''));
+        if ($name === '') {
+            throw new ApiException(422, 'invalid_request_error', 'name is required.', 'parameter_missing', 'name');
+        }
+
+        if (! Domain::query()->where('domain_uuid', $domain_uuid)->exists()) {
+            throw new ApiException(404, 'invalid_request_error', 'Domain not found.', 'resource_missing', 'domain_uuid');
+        }
+
+        $abilities = $this->normaliseAbilities($request->input('abilities'));
+
+        $expiresAt = null;
+        $expiresAtRaw = trim((string) $request->input('expires_at', ''));
+        if ($expiresAtRaw !== '') {
+            try {
+                $expiresAt = Carbon::parse($expiresAtRaw);
+            } catch (\Throwable $e) {
+                throw new ApiException(422, 'invalid_request_error', 'Invalid expires_at.', 'invalid_request', 'expires_at');
+            }
+            if ($expiresAt->isPast()) {
+                throw new ApiException(422, 'invalid_request_error', 'expires_at must be in the future.', 'invalid_request', 'expires_at');
+            }
+        }
+
+        $newToken = $user->createToken($name, $abilities, $expiresAt);
+
+        $token = $newToken->accessToken;
+        $token->forceFill(['domain_uuid' => $domain_uuid])->save();
+
+        return response()->json([
+            'object' => 'api_token',
+            'id' => (string) $token->id,
+            'name' => $token->name,
+            'type' => 'tenant',
+            'domain_uuid' => $domain_uuid,
+            'abilities' => $abilities,
+            'expires_at' => $expiresAt?->toIso8601ZuluString(),
+            'created_at' => $token->created_at?->toIso8601ZuluString(),
+            'token' => $newToken->plainTextToken,
+        ], 201);
+    }
+
+    /**
+     * Revoke a tenant-scoped API token.
+     *
+     * @group Tenant API Tokens
+     * @authenticated
+     */
+    public function destroy(Request $request, string $domain_uuid, string $token_id)
+    {
+        $this->assertUuid($domain_uuid);
+
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $token_id)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid token id.', 'invalid_request', 'token_id');
+        }
+
+        $token = PersonalAccessToken::query()
+            ->where('id', $token_id)
+            ->where('domain_uuid', $domain_uuid)
+            ->first();
+
+        if (! $token) {
+            throw new ApiException(404, 'invalid_request_error', 'Token not found.', 'resource_missing', 'token_id');
+        }
+
+        $token->delete();
+
+        return response()->json([
+            'object' => 'api_token',
+            'id' => $token_id,
+            'deleted' => true,
+        ], 200);
+    }
+
+    private function assertUuid(string $value): void
+    {
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $value)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid domain_uuid.', 'invalid_request', 'domain_uuid');
+        }
+    }
+
+    private function normaliseAbilities($abilities): array
+    {
+        $default = ['cdr:read'];
+
+        if ($abilities === null || $abilities === '' || $abilities === []) {
+            return $default;
+        }
+
+        if (is_string($abilities)) {
+            $abilities = preg_split('/\s*,\s*/', $abilities, -1, PREG_SPLIT_NO_EMPTY);
+        }
+
+        if (! is_array($abilities)) {
+            throw new ApiException(422, 'invalid_request_error', 'abilities must be an array of strings.', 'invalid_request', 'abilities');
+        }
+
+        $clean = array_values(array_unique(array_filter(array_map(fn ($a) => trim((string) $a), $abilities))));
+
+        // Prevent tenant tokens from claiming the global-read ability
+        $clean = array_values(array_filter($clean, fn ($a) => $a !== 'cdr:all-domains'));
+
+        return $clean === [] ? $default : $clean;
+    }
+
+    private function summarize(PersonalAccessToken $t): array
+    {
+        return [
+            'object' => 'api_token',
+            'id' => (string) $t->id,
+            'name' => $t->name,
+            'type' => 'tenant',
+            'domain_uuid' => $t->domain_uuid,
+            'abilities' => $t->abilities ?? [],
+            'last_used_at' => $t->last_used_at?->toIso8601ZuluString(),
+            'expires_at' => $t->expires_at?->toIso8601ZuluString(),
+            'created_at' => $t->created_at?->toIso8601ZuluString(),
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -161,6 +161,7 @@ class DatabaseSeeder extends Seeder
             ['application_name' => 'CDR API', 'permission_name' => 'cdr_api_read'],
             ['application_name' => 'CDR API', 'permission_name' => 'cdr_api_read_all_domains'],
             ['application_name' => 'CDR API', 'permission_name' => 'api_token_manage'],
+            ['application_name' => 'CDR API', 'permission_name' => 'api_token_self_manage'],
         ];
         $timestamp = date("Y-m-d H:i:s");
 

--- a/documentation/static/openapi/openapi.yaml
+++ b/documentation/static/openapi/openapi.yaml
@@ -5768,6 +5768,51 @@ paths:
         name: domain_uuid
         required: true
         schema: { type: string }
+  '/api/v1/domains/{domain_uuid}/api-tokens':
+    get:
+      summary: 'List tenant API tokens'
+      operationId: listTenantApiTokens
+      description: "Tenant self-service token management. The calling token must be bound to this `domain_uuid`, and the caller must have the `api_token_self_manage` permission."
+      responses:
+        200: { description: Success }
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+      tags: ['Tenant API Tokens']
+    post:
+      summary: 'Create a tenant API token'
+      operationId: createTenantApiToken
+      description: "Mints a token bound to this `domain_uuid`. Tenants cannot grant themselves the `cdr:all-domains` ability — it will be silently stripped."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string, example: 'Accounting dashboard' }
+                expires_at: { type: string, example: '2027-04-22T00:00:00Z' }
+                abilities: { type: array, items: { type: string }, example: [cdr:read] }
+      responses:
+        201: { description: Created }
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+      tags: ['Tenant API Tokens']
+    parameters:
+      - { in: path, name: domain_uuid, required: true, schema: { type: string } }
+  '/api/v1/domains/{domain_uuid}/api-tokens/{token_id}':
+    delete:
+      summary: 'Revoke a tenant API token'
+      operationId: revokeTenantApiToken
+      responses:
+        200: { description: Revoked }
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        404: { $ref: '#/components/responses/ResourceMissing' }
+      tags: ['Tenant API Tokens']
+    parameters:
+      - { in: path, name: domain_uuid, required: true, schema: { type: string } }
+      - { in: path, name: token_id, required: true, schema: { type: string } }
   /api/v1/admin/api-tokens:
     get:
       summary: 'List API tokens'
@@ -5909,6 +5954,9 @@ tags:
   -
     name: 'Admin API Tokens'
     description: 'Mint and revoke API tokens (internal admin only).'
+  -
+    name: 'Tenant API Tokens'
+    description: 'Self-service token management for a single tenant.'
 components:
   securitySchemes:
     default:

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Api\V1\UserController;
 use App\Http\Controllers\Api\V1\AiAgentController;
 use App\Http\Controllers\Api\V1\CdrCallController;
 use App\Http\Controllers\Api\V1\CdrStatsController;
+use App\Http\Controllers\Api\V1\TenantApiTokenController;
 use App\Http\Controllers\Api\V1\Admin\ApiTokenController;
 
 /*
@@ -229,5 +230,24 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
         Route::delete('/admin/api-tokens/{token_id}', [ApiTokenController::class, 'destroy'])
             ->name('api.v1.admin.api-tokens.destroy');
+    });
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tenant self-service API tokens
+    |--------------------------------------------------------------------------
+    | Tenant users can mint / list / revoke tokens for their own domain. The
+    | `cdr.scope:tenant` middleware locks a tenant token to the URL's
+    | {domain_uuid}. `api_token_self_manage` gates who on that domain can do it.
+    */
+    Route::middleware(['cdr.scope:tenant', 'user.authorize:api_token_self_manage'])->group(function () {
+        Route::get('/domains/{domain_uuid}/api-tokens', [TenantApiTokenController::class, 'index'])
+            ->name('api.v1.tenant.api-tokens.index');
+
+        Route::post('/domains/{domain_uuid}/api-tokens', [TenantApiTokenController::class, 'store'])
+            ->name('api.v1.tenant.api-tokens.store');
+
+        Route::delete('/domains/{domain_uuid}/api-tokens/{token_id}', [TenantApiTokenController::class, 'destroy'])
+            ->name('api.v1.tenant.api-tokens.destroy');
     });
 });

--- a/tests/Feature/Api/V1/Cdr/CdrRouteProtectionTest.php
+++ b/tests/Feature/Api/V1/Cdr/CdrRouteProtectionTest.php
@@ -84,4 +84,17 @@ class CdrRouteProtectionTest extends TestCase
         $this->getJson('/api/v1/cdr/stats/summary')
             ->assertStatus(401);
     }
+
+    public function test_tenant_tokens_list_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/api-tokens')
+            ->assertStatus(401);
+    }
+
+    public function test_tenant_tokens_create_requires_authentication(): void
+    {
+        $this->postJson('/api/v1/domains/' . self::DOMAIN . '/api-tokens', [
+            'name' => 'test',
+        ])->assertStatus(401);
+    }
 }


### PR DESCRIPTION
## Summary

Stacks on PR #5. Lets tenants mint and revoke their own CDR API tokens via `/api/v1/domains/{domain_uuid}/api-tokens` — no admin intervention needed.

## Endpoints

- `GET /api/v1/domains/{uuid}/api-tokens` — list tokens for this tenant
- `POST /api/v1/domains/{uuid}/api-tokens` — mint a new token (plain-text returned once)
- `DELETE /api/v1/domains/{uuid}/api-tokens/{token_id}` — revoke

## Guardrails

- `cdr.scope:tenant` middleware prevents cross-tenant token mutation
- New `api_token_self_manage` permission gates access (opt-in per customer)
- `cdr:all-domains` ability silently stripped if a tenant tries to self-grant it
- Tokens are always bound to the URL `{domain_uuid}` — body cannot override

## Admin path unchanged

The existing `/api/v1/admin/api-tokens` endpoints remain for internal admin use.

## Test plan

- [x] 3 new routes register with correct middleware stack
- [x] Route-protection tests pass
- [x] `route:cache` succeeds
- [ ] Seed the new permission (`php artisan db:seed --class=DatabaseSeeder`)
- [ ] Assign `api_token_self_manage` to tenant admin groups that should have it
- [ ] Smoke-test create → list → revoke with a tenant bearer token

## Follow-up

A Vue admin page for tenants to manage their tokens visually is tracked in a separate GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)