### PR TITLE
CDR CSV export + rate-limit headers

### DIFF
--- a/app/Http/Controllers/Api/V1/CdrCallController.php
+++ b/app/Http/Controllers/Api/V1/CdrCallController.php
@@ -13,6 +13,7 @@ use App\Services\Cdr\CallStatusResolver;
 use App\Services\Cdr\CdrApiFilterParser;
 use App\Services\Cdr\CdrQueryService;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class CdrCallController extends Controller
 {
@@ -214,6 +215,119 @@ class CdrCallController extends Controller
             recording_url: null, // detail endpoint returns this; list stays light
             sip_call_id: $cdr->sip_call_id,
         );
+    }
+
+    /**
+     * Stream CDRs as a CSV file.
+     *
+     * Honors the same filters + window rules as the JSON list endpoint, but
+     * streams rows row-by-row (no pagination) to keep memory flat on large
+     * exports. Capped at the server-configured max export rows.
+     *
+     * @group CDR
+     * @authenticated
+     */
+    public function exportCsv(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid, 'domain_uuid');
+        $filters = $this->filterParser->fromRequest($request);
+        return $this->streamCsv($domain_uuid, $filters);
+    }
+
+    /**
+     * Global (cross-domain) CSV export. Reachable via cdr.scope:global routes
+     * only; accepts optional `?domain_uuid=` filter.
+     *
+     * @group CDR
+     * @authenticated
+     */
+    public function globalExportCsv(Request $request)
+    {
+        $filters = $this->filterParser->fromRequest($request);
+        $domainUuid = trim((string) $request->query('domain_uuid', '')) ?: null;
+        if ($domainUuid !== null) {
+            $this->assertUuid($domainUuid, 'domain_uuid');
+        }
+        return $this->streamCsv($domainUuid, $filters);
+    }
+
+    private function streamCsv(?string $domainUuid, \App\Data\Api\V1\Cdr\CdrFilterData $filters): StreamedResponse
+    {
+        $query = $this->queries->baseQuery($domainUuid, $filters->dateFromEpoch, $filters->dateToEpoch);
+        $this->queries->applyFilters($query, $filters);
+        $query->orderBy('start_epoch');
+
+        $maxRows = (int) config('cdr.csv_max_rows', 250000);
+        $filename = sprintf(
+            'cdrs-%s-%s-to-%s.csv',
+            $domainUuid ?? 'all',
+            gmdate('Ymd', $filters->dateFromEpoch),
+            gmdate('Ymd', $filters->dateToEpoch),
+        );
+
+        $resolver = $this->statusResolver;
+
+        $callback = function () use ($query, $maxRows, $resolver) {
+            $out = fopen('php://output', 'w');
+            fputcsv($out, [
+                'xml_cdr_uuid', 'domain_uuid', 'direction', 'status',
+                'caller_id_name', 'caller_id_number', 'destination_number',
+                'start_time', 'answer_time', 'end_time',
+                'duration_sec', 'billsec_sec',
+                'hangup_cause', 'hangup_cause_q850', 'sip_hangup_disposition',
+                'extension_uuid', 'queue_uuid',
+                'mos_inbound', 'mos_outbound', 'jitter_ms', 'packet_loss',
+                'has_recording', 'sip_call_id',
+            ]);
+
+            $written = 0;
+            foreach ($query->lazyById(1000, 'xml_cdr_uuid') as $cdr) {
+                fputcsv($out, [
+                    (string) $cdr->xml_cdr_uuid,
+                    (string) $cdr->domain_uuid,
+                    $cdr->direction,
+                    $resolver->resolve($cdr)->value,
+                    $cdr->caller_id_name,
+                    $cdr->caller_id_number,
+                    $cdr->destination_number,
+                    $cdr->start_epoch ? gmdate('Y-m-d\TH:i:s\Z', (int) $cdr->start_epoch) : '',
+                    $cdr->answer_epoch ? gmdate('Y-m-d\TH:i:s\Z', (int) $cdr->answer_epoch) : '',
+                    $cdr->end_epoch ? gmdate('Y-m-d\TH:i:s\Z', (int) $cdr->end_epoch) : '',
+                    $cdr->duration,
+                    $cdr->billsec,
+                    $cdr->hangup_cause,
+                    $cdr->hangup_cause_q850,
+                    $cdr->sip_hangup_disposition,
+                    $cdr->extension_uuid,
+                    $cdr->call_center_queue_uuid,
+                    $cdr->rtp_audio_in_mos,
+                    $cdr->rtp_audio_out_mos ?? null,
+                    $cdr->rtp_audio_in_jitter_ms ?? null,
+                    $cdr->rtp_audio_in_packet_loss ?? null,
+                    empty($cdr->record_name) ? 'false' : 'true',
+                    $cdr->sip_call_id,
+                ]);
+
+                if (++$written >= $maxRows) {
+                    fputcsv($out, ['# Export truncated at ' . $maxRows . ' rows']);
+                    break;
+                }
+
+                if ($written % 500 === 0 && function_exists('ob_flush')) {
+                    @ob_flush();
+                    @flush();
+                }
+            }
+
+            fclose($out);
+        };
+
+        return response()->stream($callback, 200, [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="' . $filename . '"',
+            'X-Accel-Buffering' => 'no',
+            'Cache-Control' => 'no-store',
+        ]);
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -78,5 +78,11 @@ class RouteServiceProvider extends ServiceProvider
             $key = $request->bearerToken() ?: (optional($request->user())->id ?: $request->ip());
             return Limit::perMinute(30)->by('cdr-stats:' . $key);
         });
+
+        // CSV exports stream many rows — very tight limit, keyed by token.
+        RateLimiter::for('cdr-export', function (Request $request) {
+            $key = $request->bearerToken() ?: (optional($request->user())->id ?: $request->ip());
+            return Limit::perMinute(5)->by('cdr-export:' . $key);
+        });
     }
 }

--- a/config/cdr.php
+++ b/config/cdr.php
@@ -9,4 +9,7 @@ return [
 
     // Signed recording URL TTL (seconds).
     'recording_url_ttl' => env('CDR_RECORDING_URL_TTL', 1800),
+
+    // Maximum rows written to a single CSV export before truncation.
+    'csv_max_rows' => env('CDR_CSV_MAX_ROWS', 250000),
 ];

--- a/documentation/static/openapi/openapi.yaml
+++ b/documentation/static/openapi/openapi.yaml
@@ -5274,6 +5274,50 @@ paths:
         example: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
         required: true
         schema: { type: string }
+  '/api/v1/domains/{domain_uuid}/cdr/calls.csv':
+    get:
+      summary: 'Export CDRs as CSV'
+      operationId: exportCdrCsv
+      description: "Streams the CDR list as a CSV attachment. Accepts the same filters and window rules as the JSON list endpoint, but is not paginated. Capped at 250,000 rows (configurable). Heavily rate-limited (5 req/min)."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        - { $ref: '#/components/parameters/CdrDirection' }
+        - { $ref: '#/components/parameters/CdrStatus' }
+      responses:
+        200:
+          description: 'CSV stream'
+          content:
+            'text/csv':
+              schema: { type: string, format: binary }
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags: [CDR]
+    parameters:
+      - { in: path, name: domain_uuid, required: true, schema: { type: string } }
+  /api/v1/cdr/calls.csv:
+    get:
+      summary: 'Export CDRs as CSV (global admin)'
+      operationId: exportCdrCsvGlobal
+      description: "Fleet-wide CSV export. Requires a global admin token + `cdr_api_read_all_domains`. Optional `?domain_uuid=` to target one tenant."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        -
+          in: query
+          name: domain_uuid
+          required: false
+          schema: { type: string }
+      responses:
+        200:
+          description: 'CSV stream'
+          content:
+            'text/csv':
+              schema: { type: string, format: binary }
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags: [CDR]
   '/api/v1/domains/{domain_uuid}/cdr/calls/{xml_cdr_uuid}':
     get:
       summary: 'Retrieve a CDR'

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -168,6 +168,10 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
         Route::get('/domains/{domain_uuid}/cdr/calls/{xml_cdr_uuid}', [CdrCallController::class, 'show'])
             ->name('api.v1.cdr.calls.show');
 
+        Route::get('/domains/{domain_uuid}/cdr/calls.csv', [CdrCallController::class, 'exportCsv'])
+            ->middleware('throttle:cdr-export')
+            ->name('api.v1.cdr.calls.export');
+
         Route::middleware('throttle:cdr-stats')->group(function () {
             Route::get('/domains/{domain_uuid}/cdr/stats/summary', [CdrStatsController::class, 'summary'])
                 ->name('api.v1.cdr.stats.summary');
@@ -202,6 +206,10 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
     Route::middleware(['cdr.scope:global', 'user.authorize:cdr_api_read_all_domains'])->group(function () {
         Route::get('/cdr/calls', [CdrCallController::class, 'globalIndex'])
             ->name('api.v1.cdr.global.calls.index');
+
+        Route::get('/cdr/calls.csv', [CdrCallController::class, 'globalExportCsv'])
+            ->middleware('throttle:cdr-export')
+            ->name('api.v1.cdr.global.calls.export');
 
         Route::middleware('throttle:cdr-stats')->group(function () {
             Route::get('/cdr/stats/summary', [CdrStatsController::class, 'globalSummary'])

--- a/tests/Feature/Api/V1/Cdr/CdrRouteProtectionTest.php
+++ b/tests/Feature/Api/V1/Cdr/CdrRouteProtectionTest.php
@@ -97,4 +97,16 @@ class CdrRouteProtectionTest extends TestCase
             'name' => 'test',
         ])->assertStatus(401);
     }
+
+    public function test_csv_export_requires_authentication(): void
+    {
+        $this->get('/api/v1/domains/' . self::DOMAIN . '/cdr/calls.csv')
+            ->assertStatus(401);
+    }
+
+    public function test_global_csv_export_requires_authentication(): void
+    {
+        $this->get('/api/v1/cdr/calls.csv')
+            ->assertStatus(401);
+    }
 }


### PR DESCRIPTION
## Summary

Stacks on PR #6. Adds CSV export + documents the rate-limit headers clients get automatically.

## New endpoints

- `GET /api/v1/domains/{uuid}/cdr/calls.csv` — tenant CSV export
- `GET /api/v1/cdr/calls.csv` — global admin CSV export, optional `?domain_uuid=` filter

Same filters + 30-day window rules as the JSON list endpoints.

## Design

- **Streaming**: `lazyById(1000, 'xml_cdr_uuid')` + `fputcsv` to `php://output` keeps memory flat on million-row exports
- **Row cap**: 250,000 rows default (`CDR_CSV_MAX_ROWS` env); a marker row is appended if truncated
- **Throttle**: `throttle:cdr-export` at 5/min per token (separate bucket from JSON endpoints)
- **Nginx**: `X-Accel-Buffering: no` header so responses stream without buffering

## Rate-limit headers

Laravel's `ThrottleRequests` middleware already sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `Retry-After` on every `/api/v1/*` response. No code change needed — just documented here for clients.

## Test plan

- [x] 2 new routes register with `throttle:cdr-export`
- [x] 15 feature tests passing
- [ ] Deploy, hit `/cdr/calls.csv` with a token and open the result in a spreadsheet
- [ ] Verify `X-RateLimit-*` headers present on responses (curl -I)
- [ ] Exercise the 5/min limiter with a quick loop → expect 429 on 6th call

🤖 Generated with [Claude Code](https://claude.com/claude-code)