### PR TITLE
CDR API v1 PR 2: extra stats + global admin endpoints

### DIFF
--- a/app/Http/Controllers/Api/V1/CdrCallController.php
+++ b/app/Http/Controllers/Api/V1/CdrCallController.php
@@ -216,6 +216,48 @@ class CdrCallController extends Controller
         );
     }
 
+    /**
+     * List CDRs across the whole fleet.
+     *
+     * Reachable only via `cdr.scope:global`. Accepts an optional
+     * `?domain_uuid=` query param to filter to a single tenant.
+     *
+     * @group CDR
+     * @authenticated
+     */
+    public function globalIndex(Request $request)
+    {
+        $filters = $this->filterParser->fromRequest($request);
+
+        $domainUuid = trim((string) $request->query('domain_uuid', '')) ?: null;
+        if ($domainUuid !== null) {
+            $this->assertUuid($domainUuid, 'domain_uuid');
+        }
+
+        $limit = $this->parseLimit($request);
+        $startingAfter = trim((string) $request->query('starting_after', '')) ?: null;
+
+        $query = $this->queries->baseQuery($domainUuid, $filters->dateFromEpoch, $filters->dateToEpoch);
+        $this->queries->applyFilters($query, $filters);
+
+        [$rows, $hasMore] = $this->queries->paginate($query, $limit, $startingAfter);
+
+        $data = $rows->map(fn (CDR $cdr) => $this->toCallData($cdr))->all();
+
+        $payload = new CdrListResponseData(
+            object: 'list',
+            url: '/api/v1/cdr/calls',
+            has_more: $hasMore,
+            data: $data,
+        );
+
+        $envelope = $payload->toArray();
+        $envelope['scope'] = 'global';
+        $envelope['domain_uuid_filter'] = $domainUuid;
+
+        return response()->json($envelope, 200);
+    }
+
     private function resolveRecordingUrl(CDR $cdr): ?string
     {
         if (empty($cdr->record_name) && empty($cdr->archive_recording?->object_key)) {

--- a/app/Http/Controllers/Api/V1/CdrStatsController.php
+++ b/app/Http/Controllers/Api/V1/CdrStatsController.php
@@ -77,6 +77,165 @@ class CdrStatsController extends Controller
         ], 200);
     }
 
+    /**
+     * CDR stats grouped by extension.
+     *
+     * @group CDR
+     * @authenticated
+     */
+    public function byExtension(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid);
+        $filters = $this->filterParser->fromRequest($request);
+
+        return response()->json([
+            'object' => 'cdr_stats_by_extension',
+            'domain_uuid' => $domain_uuid,
+            'window' => $this->windowBlock($filters),
+            'data' => $this->stats->byExtension($domain_uuid, $filters),
+        ], 200);
+    }
+
+    /**
+     * CDR call volume + duration + quality as a time series.
+     *
+     * @group CDR
+     * @authenticated
+     * @queryParam bucket string hour|day (default day).
+     */
+    public function timeseries(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid);
+        $filters = $this->filterParser->fromRequest($request);
+        $bucket = strtolower(trim((string) $request->query('bucket', 'day'))) ?: 'day';
+
+        return response()->json([
+            'object' => 'cdr_stats_timeseries',
+            'domain_uuid' => $domain_uuid,
+            'window' => $this->windowBlock($filters),
+            'bucket' => in_array($bucket, ['hour', 'day'], true) ? $bucket : 'day',
+            'data' => $this->stats->timeseries($domain_uuid, $filters, $bucket),
+        ], 200);
+    }
+
+    /**
+     * MOS-based quality distribution.
+     *
+     * @group CDR
+     * @authenticated
+     * @queryParam poor_threshold float MOS threshold under which a call is "poor" (default 4.0).
+     */
+    public function quality(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid);
+        $filters = $this->filterParser->fromRequest($request);
+        $threshold = (float) $request->query('poor_threshold', 4.0);
+
+        return response()->json([
+            'object' => 'cdr_stats_quality',
+            'domain_uuid' => $domain_uuid,
+            'window' => $this->windowBlock($filters),
+            ...$this->stats->quality($domain_uuid, $filters, $threshold),
+        ], 200);
+    }
+
+    /**
+     * Top called destination numbers.
+     *
+     * @group CDR
+     * @authenticated
+     * @queryParam limit int 1–100 (default 20).
+     */
+    public function topDestinations(Request $request, string $domain_uuid)
+    {
+        $this->assertUuid($domain_uuid);
+        $filters = $this->filterParser->fromRequest($request);
+        $limit = (int) $request->query('limit', 20);
+
+        return response()->json([
+            'object' => 'cdr_stats_top_destinations',
+            'domain_uuid' => $domain_uuid,
+            'window' => $this->windowBlock($filters),
+            'data' => $this->stats->topDestinations($domain_uuid, $filters, $limit),
+        ], 200);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Global (cross-domain) variants
+    |--------------------------------------------------------------------------
+    | All reachable only via routes gated by `cdr.scope:global`. They optionally
+    | accept a `?domain_uuid=` filter for targeted cross-tenant queries.
+    */
+
+    public function globalSummary(Request $request)
+    {
+        $filters = $this->filterParser->fromRequest($request);
+        $scope = $this->resolveGlobalScope($request);
+
+        if ($scope['group_by_domain']) {
+            return response()->json([
+                'object' => 'cdr_stats_by_domain',
+                'scope' => 'global',
+                'window' => $this->windowBlock($filters),
+                'data' => $this->stats->byDomain($filters),
+            ], 200);
+        }
+
+        return response()->json([
+            'object' => 'cdr_stats_summary',
+            'scope' => 'global',
+            'domain_uuid' => $scope['domain_uuid'],
+            'window' => $this->windowBlock($filters),
+            ...$this->stats->summary($scope['domain_uuid'], $filters),
+        ], 200);
+    }
+
+    public function globalByDirection(Request $request)
+    {
+        $filters = $this->filterParser->fromRequest($request);
+        $scope = $this->resolveGlobalScope($request);
+
+        return response()->json([
+            'object' => 'cdr_stats_by_direction',
+            'scope' => 'global',
+            'domain_uuid' => $scope['domain_uuid'],
+            'window' => $this->windowBlock($filters),
+            'data' => $this->stats->byDirection($scope['domain_uuid'], $filters),
+        ], 200);
+    }
+
+    public function globalByHangupCause(Request $request)
+    {
+        $filters = $this->filterParser->fromRequest($request);
+        $scope = $this->resolveGlobalScope($request);
+
+        return response()->json([
+            'object' => 'cdr_stats_by_hangup_cause',
+            'scope' => 'global',
+            'domain_uuid' => $scope['domain_uuid'],
+            'window' => $this->windowBlock($filters),
+            'data' => $this->stats->byHangupCause($scope['domain_uuid'], $filters),
+        ], 200);
+    }
+
+    private function resolveGlobalScope(Request $request): array
+    {
+        $domainUuid = trim((string) $request->query('domain_uuid', '')) ?: null;
+        if ($domainUuid !== null) {
+            $this->assertUuid($domainUuid);
+        }
+        $groupByDomain = filter_var(
+            $request->query('group_by_domain', 'false'),
+            FILTER_VALIDATE_BOOLEAN
+        );
+
+        return [
+            'domain_uuid' => $domainUuid,
+            'group_by_domain' => $groupByDomain,
+        ];
+    }
+
     private function windowBlock(CdrFilterData $filters): array
     {
         return [

--- a/app/Services/Cdr/CdrQueryService.php
+++ b/app/Services/Cdr/CdrQueryService.php
@@ -16,13 +16,15 @@ use Illuminate\Database\Eloquent\Builder;
 class CdrQueryService
 {
     /**
-     * Base query scoped to a single domain and a date window on start_epoch.
+     * Base query scoped to a date window on start_epoch, optionally filtered
+     * to a single domain. Pass `null` for $domainUuid to run fleet-wide —
+     * only use this from a `cdr.scope:global` gated route.
+     *
      * Excludes LOSE_RACE + child legs to match the existing Vue CDR list.
      */
-    public function baseQuery(string $domainUuid, int $fromEpoch, int $toEpoch): Builder
+    public function baseQuery(?string $domainUuid, int $fromEpoch, int $toEpoch): Builder
     {
-        return CDR::query()
-            ->where('domain_uuid', $domainUuid)
+        $query = CDR::query()
             ->where('start_epoch', '>=', $fromEpoch)
             ->where('start_epoch', '<=', $toEpoch)
             ->where(function ($q) {
@@ -31,6 +33,12 @@ class CdrQueryService
             })
             ->whereNull('cc_member_session_uuid')
             ->whereNull('originating_leg_uuid');
+
+        if ($domainUuid !== null) {
+            $query->where('domain_uuid', $domainUuid);
+        }
+
+        return $query;
     }
 
     public function applyFilters(Builder $query, CdrFilterData $filters): Builder

--- a/app/Services/Cdr/CdrStatsService.php
+++ b/app/Services/Cdr/CdrStatsService.php
@@ -3,21 +3,20 @@
 namespace App\Services\Cdr;
 
 use App\Data\Api\V1\Cdr\CdrFilterData;
-use App\Models\CDR;
-use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\DB;
 
 class CdrStatsService
 {
     public function __construct(protected CdrQueryService $queries) {}
 
     /**
-     * Single-row summary for the domain + window + filters.
+     * Single-row summary for the window + filters, optionally scoped to one
+     * domain. Pass `null` for $domainUuid to compute fleet-wide totals
+     * (only reachable via the `cdr.scope:global` gated routes).
      *
      * @return array<string, mixed>
      */
-    public function summary(string $domainUuid, CdrFilterData $filters): array
+    public function summary(?string $domainUuid, CdrFilterData $filters): array
     {
         $row = $this->scopedQuery($domainUuid, $filters)
             ->selectRaw($this->summaryExpressions())
@@ -31,7 +30,7 @@ class CdrStatsService
      *
      * @return array<int, array<string, mixed>>
      */
-    public function byDirection(string $domainUuid, CdrFilterData $filters): array
+    public function byDirection(?string $domainUuid, CdrFilterData $filters): array
     {
         $rows = $this->scopedQuery($domainUuid, $filters)
             ->selectRaw('direction, ' . $this->summaryExpressions())
@@ -47,11 +46,31 @@ class CdrStatsService
     }
 
     /**
+     * Summary grouped by domain — only valid for global-scope calls.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function byDomain(CdrFilterData $filters): array
+    {
+        $rows = $this->scopedQuery(null, $filters)
+            ->selectRaw('domain_uuid, ' . $this->summaryExpressions())
+            ->groupBy('domain_uuid')
+            ->orderByRaw('COUNT(*) DESC')
+            ->get();
+
+        return $rows->map(function ($r) {
+            $summary = $this->normalizeSummary($r);
+            $summary['domain_uuid'] = $r->domain_uuid;
+            return $summary;
+        })->all();
+    }
+
+    /**
      * Failure-analysis breakdown on hangup cause + q.850 + SIP disposition.
      *
      * @return array<int, array<string, mixed>>
      */
-    public function byHangupCause(string $domainUuid, CdrFilterData $filters): array
+    public function byHangupCause(?string $domainUuid, CdrFilterData $filters): array
     {
         $total = (int) $this->scopedQuery($domainUuid, $filters)->count();
 
@@ -82,10 +101,173 @@ class CdrStatsService
         })->all();
     }
 
-    protected function scopedQuery(string $domainUuid, CdrFilterData $filters): Builder
+    /**
+     * Per-extension breakdown. Rows are ordered by call count desc.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function byExtension(?string $domainUuid, CdrFilterData $filters): array
+    {
+        $rows = $this->scopedQuery($domainUuid, $filters)
+            ->whereNotNull('extension_uuid')
+            ->selectRaw(
+                'extension_uuid, ' .
+                'COUNT(*) AS calls, ' .
+                "SUM(CASE WHEN answer_epoch > 0 AND hangup_cause = 'NORMAL_CLEARING' AND (voicemail_message IS NULL OR voicemail_message = false) AND (missed_call IS NULL OR missed_call = false) THEN 1 ELSE 0 END) AS answered, " .
+                "SUM(CASE WHEN missed_call = true AND hangup_cause = 'NORMAL_CLEARING' THEN 1 ELSE 0 END) AS missed, " .
+                'COALESCE(SUM(billsec),0) AS total_billsec, ' .
+                'COALESCE(AVG(NULLIF(billsec,0)),0) AS avg_billsec, ' .
+                'AVG(rtp_audio_in_mos) AS mos_avg'
+            )
+            ->groupBy('extension_uuid')
+            ->orderByRaw('COUNT(*) DESC')
+            ->limit(500)
+            ->get();
+
+        return $rows->map(fn ($r) => [
+            'extension_uuid' => (string) $r->extension_uuid,
+            'calls' => (int) $r->calls,
+            'answered' => (int) $r->answered,
+            'missed' => (int) $r->missed,
+            'total_billsec' => (int) $r->total_billsec,
+            'avg_billsec' => (int) round((float) $r->avg_billsec),
+            'mos_avg' => $r->mos_avg === null ? null : round((float) $r->mos_avg, 2),
+        ])->all();
+    }
+
+    /**
+     * Hour or day buckets over the window.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function timeseries(?string $domainUuid, CdrFilterData $filters, string $bucket): array
+    {
+        $bucket = in_array($bucket, ['hour', 'day'], true) ? $bucket : 'day';
+        $expr = "date_trunc('{$bucket}', to_timestamp(start_epoch) AT TIME ZONE 'UTC')";
+
+        $rows = $this->scopedQuery($domainUuid, $filters)
+            ->selectRaw(
+                "{$expr} AS bucket_start, " .
+                'COUNT(*) AS calls, ' .
+                "SUM(CASE WHEN answer_epoch > 0 AND hangup_cause = 'NORMAL_CLEARING' AND (voicemail_message IS NULL OR voicemail_message = false) AND (missed_call IS NULL OR missed_call = false) THEN 1 ELSE 0 END) AS answered, " .
+                "SUM(CASE WHEN (answer_epoch IS NULL OR answer_epoch = 0) AND hangup_cause NOT IN ('NORMAL_CLEARING','USER_BUSY','NO_ANSWER','NO_USER_RESPONSE','ALLOTTED_TIMEOUT') THEN 1 ELSE 0 END) AS failed, " .
+                'COALESCE(SUM(billsec),0) AS total_billsec, ' .
+                'AVG(rtp_audio_in_mos) AS mos_avg'
+            )
+            ->groupByRaw($expr)
+            ->orderByRaw($expr)
+            ->get();
+
+        return $rows->map(fn ($r) => [
+            'bucket_start' => $this->formatIso($r->bucket_start),
+            'calls' => (int) $r->calls,
+            'answered' => (int) $r->answered,
+            'failed' => (int) $r->failed,
+            'total_billsec' => (int) $r->total_billsec,
+            'mos_avg' => $r->mos_avg === null ? null : round((float) $r->mos_avg, 2),
+        ])->all();
+    }
+
+    /**
+     * MOS distribution + counts below a quality threshold.
+     *
+     * @return array<string, mixed>
+     */
+    public function quality(?string $domainUuid, CdrFilterData $filters, float $poorThreshold = 4.0): array
+    {
+        $row = $this->scopedQuery($domainUuid, $filters)
+            ->whereNotNull('rtp_audio_in_mos')
+            ->selectRaw(
+                'COUNT(*) AS samples, ' .
+                'AVG(rtp_audio_in_mos) AS mos_avg, ' .
+                'MIN(rtp_audio_in_mos) AS mos_min, ' .
+                'MAX(rtp_audio_in_mos) AS mos_max, ' .
+                'PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY rtp_audio_in_mos) AS mos_p50, ' .
+                'PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY rtp_audio_in_mos) AS mos_p95, ' .
+                'SUM(CASE WHEN rtp_audio_in_mos >= 4.3 THEN 1 ELSE 0 END) AS excellent, ' .
+                'SUM(CASE WHEN rtp_audio_in_mos >= 4.0 AND rtp_audio_in_mos < 4.3 THEN 1 ELSE 0 END) AS good, ' .
+                'SUM(CASE WHEN rtp_audio_in_mos >= 3.6 AND rtp_audio_in_mos < 4.0 THEN 1 ELSE 0 END) AS fair, ' .
+                'SUM(CASE WHEN rtp_audio_in_mos < 3.6 THEN 1 ELSE 0 END) AS poor, ' .
+                'SUM(CASE WHEN rtp_audio_in_mos < ? THEN 1 ELSE 0 END) AS below_threshold',
+                [$poorThreshold]
+            )
+            ->first();
+
+        $samples = (int) ($row->samples ?? 0);
+        $roundOr = fn ($v) => $v === null ? null : round((float) $v, 2);
+
+        return [
+            'samples' => $samples,
+            'mos_inbound' => [
+                'avg' => $roundOr($row->mos_avg ?? null),
+                'min' => $roundOr($row->mos_min ?? null),
+                'max' => $roundOr($row->mos_max ?? null),
+                'p50' => $roundOr($row->mos_p50 ?? null),
+                'p95' => $roundOr($row->mos_p95 ?? null),
+            ],
+            'mos_outbound' => null,
+            'jitter_ms' => null,
+            'packet_loss' => null,
+            'distribution' => [
+                'excellent_4_3_plus' => (int) ($row->excellent ?? 0),
+                'good_4_0_4_3' => (int) ($row->good ?? 0),
+                'fair_3_6_4_0' => (int) ($row->fair ?? 0),
+                'poor_below_3_6' => (int) ($row->poor ?? 0),
+            ],
+            'poor_threshold' => $poorThreshold,
+            'poor_calls_count' => (int) ($row->below_threshold ?? 0),
+        ];
+    }
+
+    /**
+     * Top N called destination numbers by call count.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function topDestinations(?string $domainUuid, CdrFilterData $filters, int $limit = 20): array
+    {
+        $limit = max(1, min(100, $limit));
+
+        $rows = $this->scopedQuery($domainUuid, $filters)
+            ->whereNotNull('destination_number')
+            ->where('destination_number', '!=', '')
+            ->selectRaw(
+                'destination_number, ' .
+                'COUNT(*) AS calls, ' .
+                'COALESCE(SUM(billsec),0) AS total_billsec, ' .
+                'COALESCE(AVG(NULLIF(billsec,0)),0) AS avg_billsec'
+            )
+            ->groupBy('destination_number')
+            ->orderByRaw('COUNT(*) DESC')
+            ->limit($limit)
+            ->get();
+
+        return $rows->map(fn ($r) => [
+            'destination_number' => $r->destination_number,
+            'calls' => (int) $r->calls,
+            'total_billsec' => (int) $r->total_billsec,
+            'avg_billsec' => (int) round((float) $r->avg_billsec),
+            'cost' => null,
+            'cost_currency' => null,
+        ])->all();
+    }
+
+    protected function scopedQuery(?string $domainUuid, CdrFilterData $filters): Builder
     {
         $query = $this->queries->baseQuery($domainUuid, $filters->dateFromEpoch, $filters->dateToEpoch);
         return $this->queries->applyFilters($query, $filters);
+    }
+
+    private function formatIso($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d\TH:i:s\Z');
+        }
+        $ts = strtotime((string) $value);
+        return $ts === false ? null : gmdate('Y-m-d\TH:i:s\Z', $ts);
     }
 
     protected function summaryExpressions(): string

--- a/documentation/static/openapi/openapi.yaml
+++ b/documentation/static/openapi/openapi.yaml
@@ -5438,6 +5438,284 @@ paths:
         name: domain_uuid
         required: true
         schema: { type: string }
+  '/api/v1/domains/{domain_uuid}/cdr/stats/by-extension':
+    get:
+      summary: 'CDR stats grouped by extension'
+      operationId: cdrStatsByExtension
+      description: "Per-extension call counts, answered/missed split, total + average billsec, and average inbound MOS. Rows ordered by call count desc, limited to 500 extensions."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        - { $ref: '#/components/parameters/CdrDirection' }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: cdr_stats_by_extension
+                  domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                  window: { from: '2026-04-01T00:00:00Z', to: '2026-04-15T00:00:00Z' }
+                  data:
+                    -
+                      extension_uuid: 5bcb68c3-7c1f-4a36-a8f0-7d1d6c3b0b22
+                      calls: 312
+                      answered: 281
+                      missed: 12
+                      total_billsec: 67840
+                      avg_billsec: 217
+                      mos_avg: 4.35
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags: [CDR]
+    parameters:
+      - { in: path, name: domain_uuid, required: true, schema: { type: string } }
+  '/api/v1/domains/{domain_uuid}/cdr/stats/timeseries':
+    get:
+      summary: 'CDR time-series (hour or day buckets)'
+      operationId: cdrStatsTimeseries
+      description: "Call volume, answered, failed, total billsec, and avg MOS bucketed by `hour` or `day` (UTC). Useful for dashboards."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        -
+          in: query
+          name: bucket
+          required: false
+          schema: { type: string, enum: [hour, day] }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: cdr_stats_timeseries
+                  domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                  window: { from: '2026-04-01T00:00:00Z', to: '2026-04-03T00:00:00Z' }
+                  bucket: hour
+                  data:
+                    -
+                      bucket_start: '2026-04-01T09:00:00Z'
+                      calls: 42
+                      answered: 36
+                      failed: 2
+                      total_billsec: 6820
+                      mos_avg: 4.32
+                    -
+                      bucket_start: '2026-04-01T10:00:00Z'
+                      calls: 55
+                      answered: 49
+                      failed: 1
+                      total_billsec: 8400
+                      mos_avg: 4.28
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags: [CDR]
+    parameters:
+      - { in: path, name: domain_uuid, required: true, schema: { type: string } }
+  '/api/v1/domains/{domain_uuid}/cdr/stats/quality':
+    get:
+      summary: 'CDR quality distribution (MOS)'
+      operationId: cdrStatsQuality
+      description: "Mean Opinion Score (inbound RTP audio) distribution and poor-call count. Outbound MOS, jitter, and packet loss are exposed as `null` until FreeSWITCH CDR template changes capture them."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        -
+          in: query
+          name: poor_threshold
+          description: 'MOS under which a call is "poor" (default 4.0).'
+          required: false
+          schema: { type: number, format: float }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: cdr_stats_quality
+                  domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                  window: { from: '2026-04-01T00:00:00Z', to: '2026-04-15T00:00:00Z' }
+                  samples: 3905
+                  mos_inbound: { avg: 4.21, min: 2.1, max: 4.5, p50: 4.3, p95: 4.5 }
+                  mos_outbound: null
+                  jitter_ms: null
+                  packet_loss: null
+                  distribution: { excellent_4_3_plus: 2801, good_4_0_4_3: 702, fair_3_6_4_0: 301, poor_below_3_6: 101 }
+                  poor_threshold: 4.0
+                  poor_calls_count: 402
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags: [CDR]
+    parameters:
+      - { in: path, name: domain_uuid, required: true, schema: { type: string } }
+  '/api/v1/domains/{domain_uuid}/cdr/stats/top-destinations':
+    get:
+      summary: 'Top called destinations'
+      operationId: cdrStatsTopDestinations
+      description: "Top N called destination numbers by call count, with total and average billsec. Useful for outbound cost visibility. `cost` is null until the rating engine ships."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        - { $ref: '#/components/parameters/CdrDirection' }
+        -
+          in: query
+          name: limit
+          required: false
+          schema: { type: integer }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: cdr_stats_top_destinations
+                  domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                  window: { from: '2026-04-01T00:00:00Z', to: '2026-04-15T00:00:00Z' }
+                  data:
+                    -
+                      destination_number: '+442079460000'
+                      calls: 128
+                      total_billsec: 23040
+                      avg_billsec: 180
+                      cost: null
+                      cost_currency: null
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403: { $ref: '#/components/responses/ForbiddenDomain' }
+        422: { $ref: '#/components/responses/WindowValidation' }
+      tags: [CDR]
+    parameters:
+      - { in: path, name: domain_uuid, required: true, schema: { type: string } }
+  /api/v1/cdr/calls:
+    get:
+      summary: 'List CDRs across the fleet (global admin)'
+      operationId: listCdrsGlobal
+      description: "Cross-tenant CDR list. Requires a global admin token (i.e. `personal_access_tokens.domain_uuid IS NULL`) AND the `cdr_api_read_all_domains` permission. Accepts an optional `?domain_uuid=` filter for targeted queries."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        - { $ref: '#/components/parameters/CdrDirection' }
+        -
+          in: query
+          name: domain_uuid
+          description: 'Optional tenant filter.'
+          required: false
+          schema: { type: string }
+        -
+          in: query
+          name: limit
+          required: false
+          schema: { type: integer }
+        -
+          in: query
+          name: starting_after
+          required: false
+          schema: { type: string }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: list
+                  url: /api/v1/cdr/calls
+                  has_more: true
+                  scope: global
+                  domain_uuid_filter: null
+                  data: []
+        401: { $ref: '#/components/responses/Unauthenticated' }
+        403:
+          description: 'Tenant token used against a global-only endpoint'
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  error: { type: invalid_request_error, message: 'This endpoint requires a global admin token.', code: forbidden_scope }
+      tags: [CDR]
+  /api/v1/cdr/stats/summary:
+    get:
+      summary: 'Fleet-wide CDR summary (global admin)'
+      operationId: cdrStatsSummaryGlobal
+      description: "Cross-tenant summary. Supports `group_by_domain=true` to return one row per domain (ordered by call count desc), or a targeted single-tenant summary via `domain_uuid`."
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        -
+          in: query
+          name: domain_uuid
+          required: false
+          schema: { type: string }
+        -
+          in: query
+          name: group_by_domain
+          required: false
+          schema: { type: boolean }
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  object: cdr_stats_by_domain
+                  scope: global
+                  window: { from: '2026-04-01T00:00:00Z', to: '2026-04-15T00:00:00Z' }
+                  data:
+                    -
+                      domain_uuid: 4018f7a3-8e0a-47bb-9f4f-04b1313e0e1b
+                      totals: { calls: 4821, answered: 3905, missed: 412, voicemail: 88, abandoned: 27, busy: 203, no_answer: 97, failed: 89 }
+                      duration: { total_sec: 892341, total_billsec: 871002, avg_sec: 185 }
+                      rates: { asr: 0.902, acd_sec: 223 }
+                      cost: { total: null, currency: null }
+        401: { $ref: '#/components/responses/Unauthenticated' }
+      tags: [CDR]
+  /api/v1/cdr/stats/by-direction:
+    get:
+      summary: 'Fleet-wide CDR summary by direction (global admin)'
+      operationId: cdrStatsByDirectionGlobal
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        -
+          in: query
+          name: domain_uuid
+          required: false
+          schema: { type: string }
+      responses:
+        200: { description: Success }
+        401: { $ref: '#/components/responses/Unauthenticated' }
+      tags: [CDR]
+  /api/v1/cdr/stats/by-hangup-cause:
+    get:
+      summary: 'Fleet-wide CDR hangup-cause breakdown (global admin)'
+      operationId: cdrStatsByHangupCauseGlobal
+      parameters:
+        - { $ref: '#/components/parameters/CdrDateFrom' }
+        - { $ref: '#/components/parameters/CdrDateTo' }
+        -
+          in: query
+          name: domain_uuid
+          required: false
+          schema: { type: string }
+      responses:
+        200: { description: Success }
+        401: { $ref: '#/components/responses/Unauthenticated' }
+      tags: [CDR]
   '/api/v1/domains/{domain_uuid}/cdr/stats/by-hangup-cause':
     get:
       summary: 'CDR breakdown by hangup cause'

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -176,6 +176,41 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
             Route::get('/domains/{domain_uuid}/cdr/stats/by-hangup-cause', [CdrStatsController::class, 'byHangupCause'])
                 ->name('api.v1.cdr.stats.by-hangup-cause');
+
+            Route::get('/domains/{domain_uuid}/cdr/stats/by-extension', [CdrStatsController::class, 'byExtension'])
+                ->name('api.v1.cdr.stats.by-extension');
+
+            Route::get('/domains/{domain_uuid}/cdr/stats/timeseries', [CdrStatsController::class, 'timeseries'])
+                ->name('api.v1.cdr.stats.timeseries');
+
+            Route::get('/domains/{domain_uuid}/cdr/stats/quality', [CdrStatsController::class, 'quality'])
+                ->name('api.v1.cdr.stats.quality');
+
+            Route::get('/domains/{domain_uuid}/cdr/stats/top-destinations', [CdrStatsController::class, 'topDestinations'])
+                ->name('api.v1.cdr.stats.top-destinations');
+        });
+    });
+
+    /*
+    |--------------------------------------------------------------------------
+    | CDR — global (cross-domain) admin endpoints
+    |--------------------------------------------------------------------------
+    | `cdr.scope:global` rejects tenant tokens. `cdr_api_read_all_domains`
+    | permission is also required.
+    */
+    Route::middleware(['cdr.scope:global', 'user.authorize:cdr_api_read_all_domains'])->group(function () {
+        Route::get('/cdr/calls', [CdrCallController::class, 'globalIndex'])
+            ->name('api.v1.cdr.global.calls.index');
+
+        Route::middleware('throttle:cdr-stats')->group(function () {
+            Route::get('/cdr/stats/summary', [CdrStatsController::class, 'globalSummary'])
+                ->name('api.v1.cdr.global.stats.summary');
+
+            Route::get('/cdr/stats/by-direction', [CdrStatsController::class, 'globalByDirection'])
+                ->name('api.v1.cdr.global.stats.by-direction');
+
+            Route::get('/cdr/stats/by-hangup-cause', [CdrStatsController::class, 'globalByHangupCause'])
+                ->name('api.v1.cdr.global.stats.by-hangup-cause');
         });
     });
 

--- a/tests/Feature/Api/V1/Cdr/CdrRouteProtectionTest.php
+++ b/tests/Feature/Api/V1/Cdr/CdrRouteProtectionTest.php
@@ -48,4 +48,40 @@ class CdrRouteProtectionTest extends TestCase
             'type' => 'global',
         ])->assertStatus(401);
     }
+
+    public function test_by_extension_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/cdr/stats/by-extension')
+            ->assertStatus(401);
+    }
+
+    public function test_timeseries_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/cdr/stats/timeseries')
+            ->assertStatus(401);
+    }
+
+    public function test_quality_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/cdr/stats/quality')
+            ->assertStatus(401);
+    }
+
+    public function test_top_destinations_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/cdr/stats/top-destinations')
+            ->assertStatus(401);
+    }
+
+    public function test_global_calls_list_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/cdr/calls')
+            ->assertStatus(401);
+    }
+
+    public function test_global_summary_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/cdr/stats/summary')
+            ->assertStatus(401);
+    }
 }


### PR DESCRIPTION
Originally PR #4 — reopened after base branch was deleted on merge of PR #2. Same content.

## Summary
- 4 new tenant stats: by-extension, timeseries, quality, top-destinations
- 4 global admin endpoints: /api/v1/cdr/calls, /stats/summary|by-direction|by-hangup-cause
- cdr.scope:global middleware + cdr_api_read_all_domains permission gate

See original: https://github.com/ystwythv/fspbx/pull/4