### PR TITLE
Add bearer-auth integration endpoints for extension lookup + push-token

### DIFF
--- a/app/Http/Controllers/ExtensionsController.php
+++ b/app/Http/Controllers/ExtensionsController.php
@@ -1097,6 +1097,37 @@ public function store(StoreExtensionRequest $request)
         }
     }
 
+    /**
+     * Resolve an extension number + domain name to their fspbx UUIDs.
+     * Used by external integrations (e.g. iqcrm) so they can populate
+     * fspbxExtensionUuid / fspbxDomainUuid without manual entry.
+     */
+    public function lookupByNumber(Request $request)
+    {
+        $request->validate([
+            'extension' => 'required|string',
+            'domain' => 'required|string',
+        ]);
+
+        $domain = \App\Models\Domain::where('domain_name', $request->input('domain'))->first();
+        if (!$domain) {
+            return response()->json(['success' => false, 'message' => 'Domain not found'], 404);
+        }
+
+        $extension = Extensions::where('domain_uuid', $domain->domain_uuid)
+            ->where('extension', $request->input('extension'))
+            ->first();
+        if (!$extension) {
+            return response()->json(['success' => false, 'message' => 'Extension not found'], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'extension_uuid' => $extension->extension_uuid,
+            'domain_uuid' => $domain->domain_uuid,
+        ]);
+    }
+
     public function devices(Request $request, $extension_uuid)
     {
 

--- a/resources/lua/push_wake.lua
+++ b/resources/lua/push_wake.lua
@@ -97,6 +97,15 @@ local curl_cmd = string.format(
 os.execute(curl_cmd)
 log("INFO", "dispatched incoming_call webhook for " .. aor)
 
+-- Force the outbound B-leg (iOS endpoint) to use the A-leg channel UUID as
+-- its SIP Call-ID, matching the value already in the push payload's
+-- `call_uuid`. Without this, mod_sofia mints a fresh Call-ID and CallKit's
+-- answer UUID (from push) doesn't align with CallManager's callUUID (from
+-- INVITE), so the answer guard fails and the call is BYE'd.
+if call_uuid ~= "" then
+    session:execute("export", "nolocal:sip_invite_call_id=" .. call_uuid)
+end
+
 if not session:ready() then return end
 session:preAnswer()
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -412,3 +412,13 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     // CHAR PMS
     Route::post('/pms/char', CharPmsWebhookController::class)->name('pms.char');
 });
+
+// Integration endpoints for external services (e.g. iqcrm) that authenticate
+// with a Sanctum personal access token. The api.token.auth middleware rejects
+// cookie/session requests so these routes are strictly machine-to-machine.
+Route::group(['middleware' => ['auth:sanctum', 'api.token.auth']], function () {
+    Route::get('/integrations/extensions/lookup', [ExtensionsController::class, 'lookupByNumber'])
+        ->name('integrations.extensions.lookup');
+    Route::post('/integrations/extensions/{extension}/push-token', [ExtensionsController::class, 'updatePushToken'])
+        ->name('integrations.extensions.push.token');
+});


### PR DESCRIPTION
## Summary

Machine-to-machine integrations (iqcrm) need to resolve extension number + domain to their fspbx UUIDs and forward APNs push tokens when the iOS app registers. The existing `/api/extensions/{uuid}/push-token` and `/api/extensions/data` routes sit behind the \`api.cookie.auth\` middleware, which rejects any request carrying \`Authorization: Bearer\` — so iqcrm's \`fspbx-client.ts\` currently 401s.

This PR adds a new \`Route::group\` using \`auth:sanctum\` + \`api.token.auth\` (bearer required, cookies rejected) exposing:

- \`GET /api/integrations/extensions/lookup?extension=820&domain=iqmobile.uk\` → \`{extension_uuid, domain_uuid}\` or 404
- \`POST /api/integrations/extensions/{uuid}/push-token\` → bearer-compatible copy of the existing SPA-only endpoint

## Depends on

Not strictly, but pairs naturally with #17 (push_wake + notifications queue). Can land independently.

## Test plan

- [ ] \`curl -H "Authorization: Bearer <token>" "https://app.voxra.uk/api/integrations/extensions/lookup?extension=820&domain=iqmobile.uk"\` returns \`{success: true, extension_uuid, domain_uuid}\`.
- [ ] Same call without the Authorization header returns 401.
- [ ] Unknown extension/domain returns 404 with \`{success: false, message}\`.
- [ ] Push-token POST with bearer persists \`apns_voip_token\` on the extension row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)