### PR TITLE
fix(push_wake): respect voicemail_enabled before voicemail fallback

### DIFF
--- a/resources/lua/push_wake.lua
+++ b/resources/lua/push_wake.lua
@@ -27,7 +27,28 @@ local PUSH_WAKE_TIMEOUT_MS = 15000
 local PUSH_WAKE_POLL_MS = 500
 
 local json = require "resources.functions.lunajson"
+local Database = require "resources.functions.database"
 local api = freeswitch.API()
+
+-- Returns true if v_voicemails.voicemail_enabled='true' for this mailbox, or
+-- nil on lookup failure / no row (caller must default safely). Used by the
+-- goto_voicemail() fallback to avoid playing mod_voicemail's "not enabled"
+-- prompt to a caller whose target extension has deliberately opted out.
+local function voicemail_is_enabled(destination_number, domain_name)
+    local dbh = Database.new('system')
+    if not (dbh and dbh:connected()) then return nil end
+    local val = dbh:first_value([[
+        select v.voicemail_enabled
+        from v_voicemails v
+        join v_domains d using(domain_uuid)
+        where d.domain_name = :domain_name
+          and v.voicemail_id = :vmid
+        limit 1
+    ]], {domain_name = domain_name, vmid = destination_number})
+    dbh:release()
+    if val == nil or val == "" then return nil end
+    return val == "true"
+end
 
 local function log(level, msg)
     freeswitch.consoleLog(level, SCRIPT_NAME .. " " .. tostring(msg) .. "\n")
@@ -276,6 +297,20 @@ end
 -- than letting push_wake_hook's `continue="true"` fall through to
 -- local_extension (which would re-bridge the same contacts).
 local function goto_voicemail(reason)
+    -- Respect v_voicemails.voicemail_enabled. Without this check we'd hand
+    -- the call to mod_voicemail even when the user has switched voicemail
+    -- off; mod_voicemail then plays a "not enabled for this user" prompt
+    -- before hanging up, which exposes a voicemail flow the user
+    -- deliberately opted out of. Treat nil (DB error / no row) as enabled
+    -- so a transient lookup failure still records to voicemail rather
+    -- than silently dropping the caller.
+    local vm_enabled = voicemail_is_enabled(destination_number, domain_name)
+    if vm_enabled == false then
+        log("INFO", string.format("%s for %s — voicemail disabled, hanging up NO_ANSWER", reason, aor))
+        if session:ready() then session:hangup("NO_ANSWER") end
+        return
+    end
+
     log("INFO", string.format("%s for %s — going to voicemail", reason, aor))
     if not session:ready() then return end
     if session:getVariable("call_answered") ~= "true" then


### PR DESCRIPTION
## Summary
- `push_wake.lua`'s `goto_voicemail()` previously called `mod_voicemail` unconditionally whenever the 15s APNs wake window expired without a matching SIP contact — even if the target extension had voicemail switched off in fspbx.
- `mod_voicemail` honours `vm-enabled=false` and plays a *"voicemail is not enabled for this user"* prompt before hanging up, which exposes the caller to a voicemail flow the user had deliberately opted out of.
- Now check `v_voicemails.voicemail_enabled` via the existing `Database.new('system')` helper (same pattern as `vm_blf.lua`) and short-circuit to a `NO_ANSWER` hangup when the mailbox is disabled.

## Why `NO_ANSWER`
SIP cause 487 lets the upstream carrier apply its own "unavailable" treatment (typically "the number you have called is not available") rather than the caller hearing a misleading voicemail prompt. It also lines up with how fspbx's `local_extension` flow treats a no-answer outcome on a vm-disabled extension.

## Safe defaults
DB-lookup failures and missing `v_voicemails` rows are treated as **enabled** so a transient connection error still falls through to mod_voicemail rather than silently dropping the caller. That matches the prior implicit default.

## Context
This came out of triaging a misrouted MT call where push_wake correctly fell through to its voicemail fallback but `mod_voicemail` wasn't loaded on the receiving node (separate fix in iqm-ansible PR #11). Once mod_voicemail loads cleanly everywhere, the next thing the path needed to respect was the per-extension voicemail toggle — this PR.

## Test plan
- [x] Lua parses cleanly via `fs_cli -x 'lua /tmp/push_wake_check.lua'` (returns the expected early-exit, no syntax error).
- [x] Reviewed against `vm_blf.lua` to confirm `Database.new('system') + dbh:first_value` is the established pattern.
- [ ] After deploy: trigger push_wake fallback on a vm-enabled extension → caller hears voicemail prompt (unchanged behaviour).
- [ ] After deploy: flip `v_voicemails.voicemail_enabled='false'` for a test extension → caller hears upstream carrier's "unavailable" treatment, log shows `[push_wake.lua] ... voicemail disabled, hanging up NO_ANSWER`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)