### PR TITLE
push_wake: ring_target=both must wait briefly for app contact

### DIFF
--- a/resources/lua/push_wake.lua
+++ b/resources/lua/push_wake.lua
@@ -25,6 +25,14 @@ local WEBHOOK_URL = "http://127.0.0.1/webhook/freeswitch"
 local WEBHOOK_SECRET = "tH0FXyxfG6Kh36*VHYdE4G!gwfE3Pf"
 local PUSH_WAKE_TIMEOUT_MS = 15000
 local PUSH_WAKE_POLL_MS = 500
+-- ring_target=both: hold the bridge for up to this long waiting for the
+-- iPhone's webrtc contact to (re-)appear after the APNs push, even though a
+-- pre-existing FMC contact would otherwise satisfy `ready_to_bridge`. Without
+-- this window the bridge is often built before the woken app has re-registered
+-- and the iPhone never receives a SIP INVITE — CallKit shows the push UI but
+-- sliding green is a local-only no-op while the SIM (or a sibling ring-group
+-- leg) actually owns the call (ystwythv/iqm-ansible#19).
+local PUSH_WAKE_BOTH_APP_WAIT_MS = 3000
 
 local json = require "resources.functions.lunajson"
 local Database = require "resources.functions.database"
@@ -251,28 +259,49 @@ if app_in_ring_set and apns_token ~= "" then
     -- iPhone — a deskphone or FMC registration that survived the WebRTC
     -- flush would short-circuit and we'd bridge to the wrong device before
     -- the app has registered.
-    -- For ring_target=both we exit on *any* contact: the FMC reg-bot is
-    -- typically already registered on the internal profile (the flush
-    -- only clears webrtc), so SIM ringing starts within one poll tick
-    -- while the iPhone continues to wake in parallel. If the app
-    -- registers before the bridge is built it joins the parallel ring;
-    -- otherwise SIM rings alone.
-    local function ready_to_bridge()
+    -- For ring_target=both we'd like to ring the SIM as soon as possible
+    -- (FMC reg-bot is usually already registered) BUT we have to leave a
+    -- short head-start for the iPhone to re-register, otherwise the bridge
+    -- is built without the app contact: CallKit then shows the push UI but
+    -- there's no SIP INVITE on the WSS for sliding green to act on, the
+    -- call lives on FMC / a sibling ring-group leg, and "first answer
+    -- wins" silently runs in the opposite direction from what the user
+    -- saw on their wrist. See ystwythv/iqm-ansible#19.
+    local function has_app_contact()
         for _, row in ipairs(query_contacts()) do
-            if row.class == "app" or ring_target == "both" then
-                return true
-            end
+            if row.class == "app" then return true end
         end
         return false
     end
+    local function has_any_contact()
+        return #query_contacts() > 0
+    end
 
     local deadline_attempts = math.floor(PUSH_WAKE_TIMEOUT_MS / PUSH_WAKE_POLL_MS)
+    local both_app_wait_attempts = math.floor(PUSH_WAKE_BOTH_APP_WAIT_MS / PUSH_WAKE_POLL_MS)
     local attempt = 0
     while attempt < deadline_attempts do
         if not session:ready() then return end
-        if ready_to_bridge() then
-            log("INFO", string.format("contact ready after %dms (ring_target=%s)",
-                attempt * PUSH_WAKE_POLL_MS, ring_target))
+        local ready = false
+        if ring_target == "app" then
+            -- Wait the full window — only the freshly-woken iPhone is acceptable.
+            ready = has_app_contact()
+        elseif ring_target == "both" then
+            -- Prefer to wait for the app, but never delay the SIM by more
+            -- than PUSH_WAKE_BOTH_APP_WAIT_MS once a non-app contact is up.
+            if has_app_contact() then
+                ready = true
+            elseif attempt >= both_app_wait_attempts and has_any_contact() then
+                ready = true
+            end
+        else
+            -- ring_target=fmc shouldn't reach this branch (apns_token check
+            -- gates the whole block), but be defensive.
+            ready = has_any_contact()
+        end
+        if ready then
+            log("INFO", string.format("contact ready after %dms (ring_target=%s, app_contact=%s)",
+                attempt * PUSH_WAKE_POLL_MS, ring_target, tostring(has_app_contact())))
             break
         end
         session:sleep(PUSH_WAKE_POLL_MS)


### PR DESCRIPTION
## Summary

- Fixes the iPhone-misses-bridge race on `ring_target=both`. The FMC reg-bot is almost always pre-registered for the AOR, so `ready_to_bridge()` returns on the very first poll tick — the bridge is built *before* the woken app has re-REGISTERed and the iPhone never receives a SIP INVITE.
- Caps the SIM ringing head-start at 3 s. While the iPhone hasn't shown up we keep waiting; the moment the `device=app` contact arrives — or after 3 s, whichever comes first — we proceed to build the bridge with whatever's present.
- No behaviour change for `ring_target=app` (still waits the full 15 s) or `ring_target=fmc` (doesn't reach this code path).

## Why it matters

Reported in [`ystwythv/iqcrmapp#6`](https://github.com/ystwythv/iqcrmapp/issues/6) and root-caused while triaging [`ystwythv/iqm-ansible#19`](https://github.com/ystwythv/iqm-ansible/issues/19). User-visible symptom:

> if I answer the call using the CRM app, it looks like it's answered i.e. the seconds counter starts counting up. Meanwhile at the exact same time, James' phone is still ringing with the exact same call, he then answers and gets the call. The call instance on my device then fails.

What was actually happening: APNs push arrived → CallKit showed the answer slider → `push_wake.lua` polled, saw the always-on FMC contact, exited the wait immediately, built `bridge sofia/internal/<fmc_contact>` (and any sibling ring-group leg). The iPhone wasn't in the bridge, so sliding green was a CallKit-only event — no SIP INVITE on the WSS, no 200 OK, no leg to win. The SIM (or James) actually owned the call and the iPhone's session was a phantom that timed out.

## Test plan

- [ ] Reproduce the original race on staging: inbound call to extension with `ring_target=both` while iPhone is force-quit. Pre-fix: CallKit answer is silently dropped, FMC SIM keeps ringing. Post-fix: iPhone joins the parallel bridge within ~1-3 s, sliding green wins and cancels the SIM.
- [ ] `ring_target=app` regression check: inbound to a push-only extension still waits the full 15 s for the iPhone's webrtc contact and never bridges to a residual FMC contact.
- [ ] `ring_target=fmc` regression check: no APNs push fires, no wait loop, SIM rings immediately.
- [ ] Voicemail fallback still triggered when neither contact appears within `PUSH_WAKE_TIMEOUT_MS`.
- [ ] Apply by running `ansible-playbook -i hosts.ini voxra.yml --tags push-wake --limit <host>` (no Ansible change needed — the file at `resources/lua/push_wake.lua` is shipped as part of the fspbx checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)