### PR TITLE
extensions: reconstruct E.164 caller ID for display

### DIFF
--- a/app/Models/Extensions.php
+++ b/app/Models/Extensions.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Spatie\Activitylog\LogOptions;
 use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
+use libphonenumber\NumberParseException;
 use Illuminate\Database\Eloquent\Model;
 use App\Services\CallRoutingOptionsService;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -159,17 +161,17 @@ class Extensions extends Model
 
     public function getOutboundCallerIdNumberFormattedAttribute()
     {
-        return formatPhoneNumber($this->outbound_caller_id_number, 'US', PhoneNumberFormat::NATIONAL);
+        return $this->formatStoredCallerId($this->outbound_caller_id_number, PhoneNumberFormat::NATIONAL);
     }
 
     public function getEmergencyCallerIdNumberE164Attribute()
     {
-        return formatPhoneNumber($this->emergency_caller_id_number, 'US', PhoneNumberFormat::E164);
+        return $this->formatStoredCallerId($this->emergency_caller_id_number, PhoneNumberFormat::E164);
     }
 
     public function getOutboundCallerIdNumberE164Attribute()
     {
-        return formatPhoneNumber($this->outbound_caller_id_number, 'US', PhoneNumberFormat::E164);
+        return $this->formatStoredCallerId($this->outbound_caller_id_number, PhoneNumberFormat::E164);
     }
 
     public function setOutboundCallerIdNumberAttribute($value)
@@ -189,6 +191,30 @@ class Extensions extends Model
         }
         // FusionPBX OUTBOUND_CALLER_ID dialplan validates with /^\d{6,25}$/ — '+' breaks it.
         return ltrim((string) $value, '+');
+    }
+
+    // The setter strips '+' before persisting, so stored values are E.164-without-the-plus.
+    // Re-add '+' here so libphonenumber can parse the number without a hard-coded region.
+    protected function formatStoredCallerId($raw, int $format)
+    {
+        if ($raw === null || $raw === '') {
+            return $raw;
+        }
+        $digits = ltrim((string) $raw, '+');
+        if (!preg_match('/^\d{6,}$/', $digits)) {
+            return $raw;
+        }
+        $e164Candidate = '+' . $digits;
+        try {
+            $util = PhoneNumberUtil::getInstance();
+            $obj  = $util->parse($e164Candidate, null);
+            if ($util->isValidNumber($obj)) {
+                return $util->format($obj, $format);
+            }
+        } catch (NumberParseException $e) {
+            // fall through
+        }
+        return $format === PhoneNumberFormat::E164 ? $e164Candidate : $raw;
     }
 
     /**


### PR DESCRIPTION
## Summary

- The setter on `outbound_caller_id_number` / `emergency_caller_id_number` strips `+` (intentional — FusionPBX's `OUTBOUND_CALLER_ID` dialplan validates with `/^\d{6,25}$/`).
- The matching `_e164` / `_formatted` accessors then called `formatPhoneNumber($raw, 'US', …)`. For non-NANP numbers (e.g. UK `+44…`), the stripped digits don't parse as US and the helper falls back to returning the raw digits.
- The extension edit modal's SelectElement compares the field value against `options.phone_numbers` (proper `+E.164`). With the stripped value coming back from the API, no match is found and the field renders empty after a save — so Saving caller ID looks like a no-op to the user even though the DB write succeeded.

This PR makes the accessors prepend `+` to the stored digits (which are always E.164-minus-the-plus by construction) and parses with `region=null`, letting libphonenumber resolve the country from the dial code. Falls back gracefully for short codes / non-E.164 values.

## Test plan

- [ ] Load the extension edit modal for ext 200 on tekels.voxra.uk → External / Emergency Caller ID show `+44127622603` selected
- [ ] Re-save with no changes; modal still shows the value after reopen
- [ ] Change the number; new selection persists across reopens
- [ ] NANP test number still round-trips (e.g. `+12135551212`)
- [ ] Short codes / empty values don't regress (no crash, no spurious `+`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)