### PR TITLE
outbound-cid: prepend '+' on E.164 CLI exported to carriers

### DIFF
--- a/app/Services/OutboundCallerIdFixer.php
+++ b/app/Services/OutboundCallerIdFixer.php
@@ -22,11 +22,21 @@ use Illuminate\Support\Facades\DB;
  */
 class OutboundCallerIdFixer
 {
+    // Matches the inner action block of the `^\d{6,25}$` condition — whether
+    // it's the stock no-op set OR an earlier patched form that omitted '+' on
+    // the E.164 CLI. Replacing the whole inner block keeps the patcher
+    // idempotent across rule shape changes.
     public const BROKEN_ACTION_PATTERN =
         '/(<condition field="\$\{outbound_caller_id_number\}" expression="\^\\\\d\{6,25\}\$" break="never">\s*\n)'
-        . '(\s*)<action application="set" data="outbound_caller_id_number=\$\{outbound_caller_id_number\}" inline="true"\/>/';
+        // [^\n]* — action data attributes can contain literal '>' (e.g. <sip:…>),
+        // so we must not stop at the first '>'. Each <action …/> sits on one line.
+        . '((?:[ \t]*<action [^\n]*\/>\s*\n)+)'
+        . '(\s*<\/condition>)/';
 
-    public const REPLACEMENT_FORMAT = "%s%s<action application=\"set\" data=\"effective_caller_id_number=\${outbound_caller_id_number}\" inline=\"true\"/>\n%s<action application=\"set\" data=\"effective_caller_id_name=\${outbound_caller_id_name}\" inline=\"true\"/>\n%s<action application=\"export\" data=\"sip_h_P-Asserted-Identity=<sip:\${outbound_caller_id_number}@\${domain_name}>\"/>";
+    // The dialplan regex (^\d{6,25}$) guarantees digits-only, so prepending
+    // '+' here always produces clean E.164 — Magrathea and similar UK carriers
+    // require the leading '+' or they substitute the default trunk CLI.
+    public const REPLACEMENT_FORMAT = "%s%s<action application=\"set\" data=\"effective_caller_id_number=+\${outbound_caller_id_number}\" inline=\"true\"/>\n%s<action application=\"set\" data=\"effective_caller_id_name=\${outbound_caller_id_name}\" inline=\"true\"/>\n%s<action application=\"export\" data=\"sip_h_P-Asserted-Identity=<sip:+\${outbound_caller_id_number}@\${domain_name}>\"/>\n%s";
 
     /**
      * @return array{dialplans_patched: int, gateways_patched: int}
@@ -54,15 +64,22 @@ class OutboundCallerIdFixer
                 continue;
             }
 
-            // Already patched — effective_caller_id_number assignment is present.
-            if (strpos($xml, 'effective_caller_id_number=${outbound_caller_id_number}') !== false) {
+            // Already on the current target — '+' prefix is present on the CLI export.
+            if (strpos($xml, 'sip_h_P-Asserted-Identity=<sip:+${outbound_caller_id_number}@') !== false) {
                 continue;
             }
 
             $count = 0;
             $newXml = preg_replace_callback(
                 self::BROKEN_ACTION_PATTERN,
-                fn ($m) => sprintf(self::REPLACEMENT_FORMAT, $m[1], $m[2], $m[2], $m[2]),
+                function ($m) {
+                    // Use the indent of the first inner action for new lines.
+                    $indent = '';
+                    if (preg_match('/^([ \t]+)</m', $m[2], $im)) {
+                        $indent = $im[1];
+                    }
+                    return sprintf(self::REPLACEMENT_FORMAT, $m[1], $indent, $indent, $indent, $m[3]);
+                },
                 $xml,
                 -1,
                 $count,


### PR DESCRIPTION
## Summary

Live bug observed on app.voxra.uk: outbound call from ext 200@tekels.voxra.uk → 07944779309 arrived at the called party with the carrier's default trunk CLI, not the extension's configured number `+44127622603`.

Trace (voxra-pbx-lon1 freeswitch.log, call uuid `9f7a141c-…`):
- Dialplan reads `outbound_caller_id_number=44127622603` (no `+` — model setter strips it to satisfy FusionPBX's `^\d{6,25}$` regex).
- Patched OUTBOUND_CALLER_ID condition exports the value verbatim:
  - `effective_caller_id_number=44127622603`
  - `sip_h_P-Asserted-Identity=<sip:44127622603@tekels.voxra.uk>`
- Magrathea (carrier on `213.166.4.132`) can't parse this as valid E.164 and substitutes its default trunk CLI.

## Fix

The dialplan condition `^\d{6,25}$` already guarantees digits-only, so prepending `+` in the patched `<action>` lines always produces clean E.164.

Also:
- Broadens the regex so the patcher can update dialplans already half-patched (effective_caller_id_number set but without the `+`). Action data attributes contain literal `>` (e.g. `<sip:…>`), so the action-line match uses `[^\n]*` rather than `[^>]*`.
- Switches idempotency check to look for the new target form (`<sip:+\${outbound_caller_id_number}@`).

## Test plan

- [ ] Deploy via `ansible-playbook voxra.yml --tags fspbx --limit voxra`; `Fix OUTBOUND_CALLER_ID dialplan and gateway caller_id_in_from` step shows dialplans patched > 0.
- [ ] Inspect `v_dialplans` row for OUTBOUND_CALLER_ID: both effective_caller_id_number and PAI URI use `+\${outbound_caller_id_number}`.
- [ ] Place outbound call 200@tekels.voxra.uk → mobile; called party sees `+44127622603`.
- [ ] Re-run the patcher; reports `dialplans patched: 0` (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)