### PR TITLE
outbound-cid: invalidate per-domain dialplan cache after patching

### DIFF
--- a/app/Services/OutboundCallerIdFixer.php
+++ b/app/Services/OutboundCallerIdFixer.php
@@ -53,9 +53,11 @@ class OutboundCallerIdFixer
     {
         $rows = DB::table('v_dialplans')
             ->where('dialplan_name', 'OUTBOUND_CALLER_ID')
-            ->get(['dialplan_uuid', 'dialplan_xml']);
+            ->get(['dialplan_uuid', 'dialplan_xml', 'domain_uuid']);
 
         $patched = 0;
+        $patchedDomainUuids = [];
+        $patchedGlobal = false;
 
         foreach ($rows as $row) {
             $xml = $row->dialplan_xml;
@@ -93,14 +95,45 @@ class OutboundCallerIdFixer
                         'update_date' => date('Y-m-d H:i:s'),
                     ]);
                 $patched++;
+                if ($row->domain_uuid) {
+                    $patchedDomainUuids[$row->domain_uuid] = true;
+                } else {
+                    // A global OUTBOUND_CALLER_ID rule is reused by every domain,
+                    // so all per-domain dialplan caches need invalidation.
+                    $patchedGlobal = true;
+                }
             }
         }
 
         if ($patched > 0) {
-            FusionCache::clear('dialplan:public');
+            // FusionPBX renders OUTBOUND_CALLER_ID into the per-domain dialplan
+            // cache file (/var/cache/fusionpbx/dialplan.<domain>), not into
+            // dialplan.public.* — the cache must be cleared by domain name or
+            // the stale XML keeps serving and the DB write looks like a no-op.
+            $domainNames = $this->resolveDomainNames(
+                $patchedGlobal ? null : array_keys($patchedDomainUuids)
+            );
+            foreach ($domainNames as $domainName) {
+                FusionCache::clear('dialplan:' . $domainName);
+            }
         }
 
         return $patched;
+    }
+
+    /**
+     * @param array<int, string>|null $domainUuids null = all domains
+     * @return array<int, string>
+     */
+    protected function resolveDomainNames(?array $domainUuids): array
+    {
+        // No enabled-filter: we're just deleting cache files. Even if a domain
+        // is disabled, evicting its stale cache is safe and the rebuild lazy.
+        $q = DB::table('v_domains');
+        if ($domainUuids !== null) {
+            $q->whereIn('domain_uuid', $domainUuids);
+        }
+        return $q->pluck('domain_name')->all();
     }
 
     protected function patchGateways(): int


### PR DESCRIPTION
## Summary

Follow-up to #22. After that PR landed, the DB rows on both Voxra hosts were rewritten correctly with the `+` prefix, but FreeSWITCH kept serving the **stale** per-domain dialplan cache file (`/var/cache/fusionpbx/dialplan.tekels.voxra.uk`), so outbound calls still went to Magrathea with the wrong CLI until I `rm`'d the cache file by hand.

Root cause: `OutboundCallerIdFixer::patchDialplans()` was clearing `dialplan:public` after a successful patch — but `OUTBOUND_CALLER_ID` lives in the **per-domain** dialplan cache (`dialplan.<domain>`), not in the public DID cache.

This is the third hit of the same FSPBX file-cache gotcha on Voxra (prior: inbound DID 2026-04-21, outbound iqmobile route 2026-05-03). Documented in [memory note feedback_fspbx_file_cache.md], but the patcher itself wasn't following the rule.

## Change

- Capture `domain_uuid` for each OUTBOUND_CALLER_ID row we actually rewrite.
- After the loop, resolve those UUIDs to `domain_name`s and call `FusionCache::clear('dialplan:<domain>')` for each — this both `cache delete`s in FS and `rm`s the file in `/var/cache/fusionpbx/`.
- If a patched row had no `domain_uuid` (global rule, reused by every domain), sweep all `v_domains` instead.

## Test plan

- [ ] Deploy via `ansible-playbook voxra.yml --tags fspbx --limit voxra`.
- [ ] Manually re-introduce the old (no-`+`) XML into one `v_dialplans` row, run `php artisan pbx:fix-outbound-cid`, confirm:
  - DB row rewritten with `+` prefix
  - `/var/cache/fusionpbx/dialplan.<domain>` for that row's domain is deleted
- [ ] Outbound call from that domain succeeds with `+E.164` CLI without manual cache eviction.
- [ ] Re-run the patcher; reports `dialplans patched: 0` and does not touch caches (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)