### PR TITLE
push: send "call cancelled" background push to dismiss ghost CallKit calls

### DIFF
--- a/app/Http/Webhooks/Jobs/ProcessFreeswitchWebhookJob.php
+++ b/app/Http/Webhooks/Jobs/ProcessFreeswitchWebhookJob.php
@@ -4,6 +4,7 @@ namespace App\Http\Webhooks\Jobs;
 
 use App\Jobs\CreateVoicemailEscalationNotificationsJob;
 use App\Jobs\HandleVoicemailEscalationAttemptEventJob;
+use App\Jobs\SendCallCancelledPushJob;
 use App\Jobs\SendIncomingCallPushJob;
 use App\Jobs\SendNewVoicemailNotificationByEmail;
 use App\Jobs\SendNewVoicemailNotificationBySms;
@@ -131,6 +132,10 @@ class ProcessFreeswitchWebhookJob extends SpatieProcessWebhookJob
 
                     case 'incoming_call':
                         SendIncomingCallPushJob::dispatch($data);
+                        break;
+
+                    case 'call_cancelled':
+                        SendCallCancelledPushJob::dispatch($data);
                         break;
 
                     case 'transcribe_call':

--- a/app/Jobs/SendCallCancelledPushJob.php
+++ b/app/Jobs/SendCallCancelledPushJob.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Domain;
+use App\Models\Extensions;
+use App\Services\ApnsPushService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Send a "call cancelled" background push to the iOS apps that were woken by
+ * an incoming-call VoIP push but did not win the call (a sibling ring-group
+ * member or the SIM answered, or the caller hung up). Without this the losing
+ * apps ring as a phantom until their own client-side watchdog fires, because
+ * — having registered after the bridge was built — they never receive an
+ * INVITE and so never receive a SIP CANCEL.
+ *
+ * Fired by FreeSWITCH's cancel_push.lua (call_cancelled webhook) from the
+ * inbound leg's api_on_answer / api_hangup_hook. The push carries the original
+ * call_uuid; the app dismisses CallKit only if that call is still
+ * ringing-from-push, so notifying every pushed member is safe.
+ */
+class SendCallCancelledPushJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $tries = 2;
+    public $timeout = 20;
+    public $backoff = [3];
+
+    public function __construct(
+        private array $data,
+    ) {
+        $this->onQueue('notifications');
+    }
+
+    public function handle(ApnsPushService $apns): void
+    {
+        $callUuid = $this->data['call_uuid'] ?? '';
+        $domainName = $this->data['domain_name'] ?? null;
+        $extensions = $this->data['extensions'] ?? [];
+
+        if ($callUuid === '' || !$domainName || !is_array($extensions) || empty($extensions)) {
+            Log::warning('[CallCancelledPush] Invalid payload', $this->data);
+            return;
+        }
+
+        $domain = Domain::where('domain_name', $domainName)->first();
+        if (!$domain) {
+            Log::warning('[CallCancelledPush] Domain not found', ['domain_name' => $domainName]);
+            return;
+        }
+
+        foreach ($extensions as $extNumber) {
+            $extension = Extensions::where('domain_uuid', $domain->domain_uuid)
+                ->where('extension', (string) $extNumber)
+                ->first();
+            if (!$extension) {
+                continue;
+            }
+
+            // Cancel travels on the alert (background) channel only. A VoIP
+            // token can't carry it (wrong APNs topic) and a VoIP cancel would
+            // re-trigger CallKit's "must report a call" rule — so if no alert
+            // token is registered we skip and let the app's watchdog clean up.
+            $deviceToken = $extension->apns_alert_token;
+            if (!$deviceToken) {
+                Log::info('[CallCancelledPush] No alert token; skipping (client watchdog will clear)', [
+                    'extension' => $extNumber,
+                ]);
+                continue;
+            }
+
+            $apns->sendCallCancelledPush($deviceToken, $callUuid);
+        }
+    }
+}

--- a/app/Services/ApnsPushService.php
+++ b/app/Services/ApnsPushService.php
@@ -83,6 +83,29 @@ class ApnsPushService
     }
 
     /**
+     * Send a "call cancelled" background push so the iOS app dismisses a
+     * CallKit call it was woken for by an earlier incoming-call push.
+     *
+     * Delivered on the alert channel (silent `content-available`, NOT VoIP) on
+     * purpose: a VoIP push obliges the app to report a call to CallKit or iOS
+     * terminates it, which is the opposite of what we want here. The app
+     * switches on `type` in RemoteNotificationService and only dismisses the
+     * call when the matching `call_uuid` is still ringing-from-push — a device
+     * that actually answered ignores it — so it is safe to fan this out to
+     * every member that was pushed for the call.
+     */
+    public function sendCallCancelledPush(string $deviceToken, string $callUuid): bool
+    {
+        $payload = [
+            'aps' => ['content-available' => 1],
+            'type' => 'call_cancelled',
+            'call_uuid' => $callUuid,
+        ];
+
+        return $this->send($deviceToken, $payload, 'alert');
+    }
+
+    /**
      * Send a push notification via APNs HTTP/2 API.
      */
     private function send(string $deviceToken, array $payload, string $pushType = 'voip'): bool


### PR DESCRIPTION
When a ring-group member or the SIM answers (or the caller hangs up), the iOS apps pushed for the call that didn't win are left ringing as a phantom until their client-side watchdog — having registered after the bridge was built, they never get an INVITE and so never a SIP CANCEL.

Adds:
- `call_cancelled` webhook event → `SendCallCancelledPushJob`
- `ApnsPushService::sendCallCancelledPush()` — silent background push `{aps:{content-available:1}, type:"call_cancelled", call_uuid}` to each pushed member's `apns_alert_token` (alert channel, **not** VoIP, so no CallKit must-report obligation)

The app dismisses the matching CallKit call only while still ringing-from-push, so the winner ignores it — safe to fan out to every pushed member. Reuses existing webhook auth + APNs JWT infra; no new config/DB.

Fired by FreeSWITCH `cancel_push.lua` (iqm-ansible). Pairs with **iqcrmapp#voxra-call-cancelled-push**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)