### PR TITLE
calls: forward cancel reason in call_cancelled push

### DIFF
--- a/app/Jobs/SendCallCancelledPushJob.php
+++ b/app/Jobs/SendCallCancelledPushJob.php
@@ -44,6 +44,10 @@ class SendCallCancelledPushJob implements ShouldQueue
         $callUuid = $this->data['call_uuid'] ?? '';
         $domainName = $this->data['domain_name'] ?? null;
         $extensions = $this->data['extensions'] ?? [];
+        // Why the call was cancelled: "answered_elsewhere" (a sibling member or
+        // the SIM answered) lets the app log it as handled-elsewhere instead of
+        // missed; "caller_cancelled" stays missed. Optional / may be absent.
+        $reason = $this->data['reason'] ?? null;
 
         if ($callUuid === '' || !$domainName || !is_array($extensions) || empty($extensions)) {
             Log::warning('[CallCancelledPush] Invalid payload', $this->data);
@@ -76,7 +80,7 @@ class SendCallCancelledPushJob implements ShouldQueue
                 continue;
             }
 
-            $apns->sendCallCancelledPush($deviceToken, $callUuid);
+            $apns->sendCallCancelledPush($deviceToken, $callUuid, $reason);
         }
     }
 }

--- a/app/Services/ApnsPushService.php
+++ b/app/Services/ApnsPushService.php
@@ -94,13 +94,20 @@ class ApnsPushService
      * that actually answered ignores it — so it is safe to fan this out to
      * every member that was pushed for the call.
      */
-    public function sendCallCancelledPush(string $deviceToken, string $callUuid): bool
+    public function sendCallCancelledPush(string $deviceToken, string $callUuid, ?string $reason = null): bool
     {
         $payload = [
             'aps' => ['content-available' => 1],
             'type' => 'call_cancelled',
             'call_uuid' => $callUuid,
         ];
+
+        // Optional reason lets the app classify the CallKit Recents entry:
+        // "answered_elsewhere"/"declined_elsewhere" clears the missed-call badge,
+        // "caller_cancelled" stays missed. Absent = legacy missed behaviour.
+        if ($reason !== null && $reason !== '') {
+            $payload['reason'] = $reason;
+        }
 
         return $this->send($deviceToken, $payload, 'alert');
     }


### PR DESCRIPTION
## What

Forward an optional `reason` field through the `call_cancelled` APNs push so the iOS app can classify the CallKit Recents entry correctly.

- `ApnsPushService::sendCallCancelledPush()` gains a nullable `$reason` and includes it in the payload when present.
- `SendCallCancelledPushJob` reads `data.reason` from the FreeSWITCH webhook and passes it through.

## Why

Calls answered on a sibling device (another app, the desk phone, or the SIM via FMC) previously logged as red "missed calls" on every losing device. With the reason plumbed through, the app reports `CXCallEndedReason.answeredElsewhere` and the missed badge is cleared.

## Companion changes
- **iqcrmapp** (pushed to main): app reads `reason` → maps to `CXCallEndedReason`.
- **iqm-ansible** (separate PR): `cancel_push.lua` emits the reason; ring-group pre-pass arms `api_on_answer=…answered_elsewhere` / `api_hangup_hook=…caller_cancelled`.

Absent reason preserves existing missed behaviour, so this is backward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)