### PR TITLE
voicemail: respect TTS provider selection in greeting generation

### DIFF
--- a/app/Http/Controllers/VoicemailController.php
+++ b/app/Http/Controllers/VoicemailController.php
@@ -14,6 +14,7 @@ use App\Models\VoicemailDestinations;
 use App\Models\VoicemailGreetings;
 use App\Models\Voicemails;
 use App\Services\OpenAIService;
+use App\Services\Tts\TtsProviderRegistry;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Process;
@@ -778,16 +779,19 @@ class VoicemailController extends Controller
         return $permissions;
     }
 
-    public function textToSpeech(Voicemails $voicemail, OpenAIService $openAIService, TextToSpeechRequest $request)
+    public function textToSpeech(Voicemails $voicemail, TtsProviderRegistry $registry, TextToSpeechRequest $request)
     {
         $input = $request->input('input');
-        $model = $request->input('model');
-        $voice = $request->input('voice');
         $responseFormat = $request->input('response_format');
-        $speed = $request->input('speed');
 
         try {
-            $response = $openAIService->textToSpeech($model, $input, $voice, $responseFormat, $speed);
+            $provider = $registry->make($request->input('provider'));
+            $response = $provider->textToSpeech($input, [
+                'model'           => $request->input('model'),
+                'voice'           => $request->input('voice'),
+                'response_format' => $responseFormat,
+                'speed'           => $request->input('speed'),
+            ]);
 
             $domainName = session('domain_name');
 
@@ -830,16 +834,19 @@ class VoicemailController extends Controller
         }
     }
 
-    public function textToSpeechForName(Voicemails $voicemail, OpenAIService $openAIService, TextToSpeechRequest $request)
+    public function textToSpeechForName(Voicemails $voicemail, TtsProviderRegistry $registry, TextToSpeechRequest $request)
     {
         $input = $request->input('input');
-        $model = $request->input('model');
-        $voice = $request->input('voice');
         $responseFormat = $request->input('response_format');
-        $speed = $request->input('speed');
 
         try {
-            $response = $openAIService->textToSpeech($model, $input, $voice, $responseFormat, $speed);
+            $provider = $registry->make($request->input('provider'));
+            $response = $provider->textToSpeech($input, [
+                'model'           => $request->input('model'),
+                'voice'           => $request->input('voice'),
+                'response_format' => $responseFormat,
+                'speed'           => $request->input('speed'),
+            ]);
 
             $domainName = session('domain_name');
 


### PR DESCRIPTION
## Problem

In the **New Voicemail Greeting** / **New Recorded Name** modals (voicemail + extension pages), selecting **TTS Provider = ElevenLabs** still sent the request to OpenAI, which rejected the ElevenLabs voice ID:

> There was an error with your request: Invalid value: 'jRAAK67SEFE9m7ci5DhD'. Supported values are: 'alloy', 'echo', 'fable', ...

## Cause

`NewGreetingForm.vue` correctly sends a `provider` field, and `GreetingsController::textToSpeech` (used by virtual receptionists and ring groups) correctly routes through `TtsProviderRegistry` — but `VoicemailController::textToSpeech` and `textToSpeechForName` still hardcoded `OpenAIService`, ignoring the provider.

## Fix

Route both voicemail TTS methods through `TtsProviderRegistry`, matching the `GreetingsController` pattern. `provider=null` still falls back to the `tts_provider` domain setting → OpenAI, so existing behaviour is unchanged.

Note for upstream PR nemerald-voip/fspbx#418: this commit should be folded in alongside `f0ffedc3` if the TTS provider abstraction is upstreamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)