### PR TITLE
security: remove hardcoded webhook/internal HMAC secrets, rotate via env + vars.xml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,3 +170,10 @@ REVERB_HOST=127.0.0.1
 REVERB_PORT=8095
 REVERB_SCHEME=http
 VITE_REVERB_APP_KEY=
+# HMAC secret for the FreeSWITCH -> Laravel webhook (/webhook/freeswitch).
+# Must match the push_webhook_secret FreeSWITCH global var in vars.xml.
+FREESWITCH_WEBHOOK_SECRET=
+
+# HMAC secret for FreeSWITCH Lua -> Laravel internal orchestration calls.
+# Must match the voxra_internal_secret FreeSWITCH global var in vars.xml.
+VOXRA_INTERNAL_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ modules_statuses.json
 
 # Scribe generated docs/cache
 .scribe/
+
+# Claude Code agent worktrees
+.claude/worktrees/

--- a/app/Console/Daemons/cdr_import.php
+++ b/app/Console/Daemons/cdr_import.php
@@ -1009,8 +1009,20 @@ if (!class_exists('cdr_import')) {
                     //notify transcription service
 						if (isset($record_path) && isset($record_name) && file_exists($record_path.'/'.$record_name)) {
 
-                            $url  = 'https://127.0.0.1/webhook/freeswitch';
-                            $secret = 'tH0FXyxfG6Kh36*VHYdE4G!gwfE3Pf';
+                            $url  = getenv('FREESWITCH_WEBHOOK_URL') ?: 'https://127.0.0.1/webhook/freeswitch';
+                            // This daemon does not boot Laravel, so fall back to
+                            // reading the shared secret straight from the app .env.
+                            $secret = getenv('FREESWITCH_WEBHOOK_SECRET') ?: '';
+                            if ($secret === '') {
+                                $env_file = dirname(__DIR__, 3) . '/.env';
+                                if (is_readable($env_file) && preg_match('/^FREESWITCH_WEBHOOK_SECRET=(.*)$/m', file_get_contents($env_file), $env_match)) {
+                                    $secret = trim($env_match[1], " \t\"'\r");
+                                }
+                            }
+                            if ($secret === '') {
+                                echo "FREESWITCH_WEBHOOK_SECRET not configured - skipping transcribe_call webhook\n";
+                            }
+                            else {
                             $payload = [
                                 'event'      => 'transcribe_call',
                                 'timestamp'  => gmdate('c'),
@@ -1045,6 +1057,7 @@ if (!class_exists('cdr_import')) {
 
                             echo $response;
                             echo curl_error($ch);
+                            }
                         }
 
 					//debug

--- a/config/services.php
+++ b/config/services.php
@@ -75,9 +75,9 @@ return [
     'voxra_internal' => [
         // Shared HMAC secret used by FreeSWITCH Lua scripts to call back into
         // Laravel for synchronous orchestration (e.g. summoning the reception
-        // agent into a 3-way conference). Mirrors the legacy hard-coded value
-        // baked into the existing Lua webhook scripts; override via env.
-        'secret' => env('VOXRA_INTERNAL_SECRET', 'tH0FXyxfG6Kh36*VHYdE4G!gwfE3Pf'),
+        // agent into a 3-way conference). The Lua scripts read the same value
+        // from the voxra_internal_secret FreeSWITCH global var (vars.xml).
+        'secret' => env('VOXRA_INTERNAL_SECRET', ''),
     ],
 
     'elevenlabs' => [

--- a/config/webhook-client.php
+++ b/config/webhook-client.php
@@ -665,7 +665,7 @@ return [
              * We expect that every webhook call will be signed using a secret. This secret
              * is used to verify that the payload has not been tampered with.
              */
-            'signing_secret' => 'tH0FXyxfG6Kh36*VHYdE4G!gwfE3Pf',
+            'signing_secret' => env('FREESWITCH_WEBHOOK_SECRET', ''),
 
             /*
              * The name of the header containing the signature.

--- a/resources/lua/push_wake.lua
+++ b/resources/lua/push_wake.lua
@@ -21,8 +21,6 @@
 --      or at timeout (falls through to forward_user_not_registered).
 
 local SCRIPT_NAME = "[push_wake.lua]"
-local WEBHOOK_URL = "http://127.0.0.1/webhook/freeswitch"
-local WEBHOOK_SECRET = "tH0FXyxfG6Kh36*VHYdE4G!gwfE3Pf"
 local PUSH_WAKE_TIMEOUT_MS = 15000
 local PUSH_WAKE_POLL_MS = 500
 -- ring_target=both: hold the bridge for up to this long waiting for the
@@ -37,6 +35,23 @@ local PUSH_WAKE_BOTH_APP_WAIT_MS = 3000
 local json = require "resources.functions.lunajson"
 local Database = require "resources.functions.database"
 local api = freeswitch.API()
+
+-- Webhook endpoint + HMAC secret come from FreeSWITCH global vars (vars.xml):
+--   <X-PRE-PROCESS cmd="set" data="push_webhook_url=..."/>
+--   <X-PRE-PROCESS cmd="set" data="push_webhook_secret=..."/>
+-- The secret must match FREESWITCH_WEBHOOK_SECRET in the Laravel .env.
+local WEBHOOK_URL = api:executeString("global_getvar push_webhook_url")
+if not WEBHOOK_URL or WEBHOOK_URL == "" then
+    WEBHOOK_URL = "http://127.0.0.1/webhook/freeswitch"
+end
+
+local WEBHOOK_SECRET = api:executeString("global_getvar push_webhook_secret")
+if not WEBHOOK_SECRET or WEBHOOK_SECRET == "" then
+    -- No secret configured — bail. Without HMAC the webhook handler will
+    -- reject the request anyway.
+    freeswitch.consoleLog("WARNING", SCRIPT_NAME .. " push_webhook_secret not set — skipping push\n")
+    return
+end
 
 -- Returns true if v_voicemails.voicemail_enabled='true' for this mailbox, or
 -- nil on lookup failure / no row (caller must default safely). Used by the

--- a/resources/lua/send_webhook.lua
+++ b/resources/lua/send_webhook.lua
@@ -10,8 +10,19 @@ function debug_log(level, message)
 end
 
 local payload = argv[1] or ""
-local url = "http://127.0.0.1/webhook/freeswitch"
-local secret = "tH0FXyxfG6Kh36*VHYdE4G!gwfE3Pf"
+
+-- Webhook endpoint + HMAC secret come from FreeSWITCH global vars (vars.xml);
+-- the secret must match FREESWITCH_WEBHOOK_SECRET in the Laravel .env.
+local api = freeswitch.API()
+local url = api:executeString("global_getvar push_webhook_url")
+if not url or url == "" then
+    url = "http://127.0.0.1/webhook/freeswitch"
+end
+local secret = api:executeString("global_getvar push_webhook_secret")
+if not secret or secret == "" then
+    debug_log("ERR", "[notify_webhook.lua] push_webhook_secret not set — skipping webhook\n")
+    return
+end
 
 if payload == "" then
     debug_log("ERR", "Payload required!\n")

--- a/resources/lua/voxra_announced_settle.lua
+++ b/resources/lua/voxra_announced_settle.lua
@@ -13,7 +13,15 @@
 
 local SCRIPT_NAME = "[voxra_announced_settle.lua]"
 local URL    = "http://127.0.0.1/internal/voxra/reception-agent/announced-settle"
-local SECRET = "tH0FXyxfG6Kh36*VHYdE4G!gwfE3Pf"
+
+-- HMAC secret from FreeSWITCH global vars (vars.xml); must match
+-- VOXRA_INTERNAL_SECRET in the Laravel .env.
+local api = freeswitch.API()
+local SECRET = api:executeString("global_getvar voxra_internal_secret")
+if not SECRET or SECRET == "" then
+    freeswitch.consoleLog("ERR", SCRIPT_NAME .. " voxra_internal_secret not set — aborting\n")
+    return
+end
 
 local function log(level, msg)
     freeswitch.consoleLog(level, SCRIPT_NAME .. " " .. tostring(msg) .. "\n")

--- a/resources/lua/voxra_summon_reception_agent.lua
+++ b/resources/lua/voxra_summon_reception_agent.lua
@@ -15,7 +15,15 @@
 
 local SCRIPT_NAME = "[voxra_summon_reception_agent.lua]"
 local URL    = "http://127.0.0.1/internal/voxra/reception-agent/summon"
-local SECRET = "tH0FXyxfG6Kh36*VHYdE4G!gwfE3Pf"
+
+-- HMAC secret from FreeSWITCH global vars (vars.xml); must match
+-- VOXRA_INTERNAL_SECRET in the Laravel .env.
+local api = freeswitch.API()
+local SECRET = api:executeString("global_getvar voxra_internal_secret")
+if not SECRET or SECRET == "" then
+    freeswitch.consoleLog("ERR", SCRIPT_NAME .. " voxra_internal_secret not set — aborting\n")
+    return
+end
 
 local function log(level, msg)
     freeswitch.consoleLog(level, SCRIPT_NAME .. " " .. tostring(msg) .. "\n")


### PR DESCRIPTION
The shared HMAC secret `tH0FX...` was hardcoded in 7 files — including `config/webhook-client.php`, which is part of the public upstream PR #424 diff, so it must be treated as leaked and rotated.

This PR makes every consumer configuration-driven:

| File | Now reads from |
|------|----------------|
| `resources/lua/push_wake.lua` | `push_webhook_url` / `push_webhook_secret` FS global vars |
| `resources/lua/send_webhook.lua` | same |
| `resources/lua/voxra_summon_reception_agent.lua` | `voxra_internal_secret` FS global var |
| `resources/lua/voxra_announced_settle.lua` | same |
| `config/webhook-client.php` | `FREESWITCH_WEBHOOK_SECRET` env |
| `config/services.php` (voxra_internal) | `VOXRA_INTERNAL_SECRET` env (no default) |
| `app/Console/Daemons/cdr_import.php` | getenv → .env file fallback (daemon doesn't boot Laravel) |

All lua scripts fail safe (skip + log) when the secret is unset.

**Deploy order matters:** new secrets go into `.env` + `vars.xml` on both servers *before* this deploys (old code ignores them; new code picks them up at config:cache / next lua invocation). Server config + ansible changes are being done alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)