### PR TITLE
Harden integration lookup: token domain scoping + rate limit

### DIFF
--- a/app/Http/Controllers/ExtensionsController.php
+++ b/app/Http/Controllers/ExtensionsController.php
@@ -1139,6 +1139,21 @@ public function store(StoreExtensionRequest $request)
             return response()->json(['success' => false, 'message' => 'Domain not found'], 404);
         }
 
+        // Enforce tenant scope. A personal access token with a non-null
+        // domain_uuid is a tenant token and may only resolve extensions in
+        // its own domain. A null domain_uuid is a global/admin token and may
+        // resolve any domain. This prevents cross-tenant info disclosure
+        // (any valid Sanctum token resolving any extension in any domain).
+        $token = $request->user()?->currentAccessToken();
+        $tokenDomain = $token && $token->domain_uuid ? (string) $token->domain_uuid : null;
+
+        if ($tokenDomain !== null && $tokenDomain !== (string) $domain->domain_uuid) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This token is not permitted to access that domain',
+            ], 403);
+        }
+
         $extension = Extensions::where('domain_uuid', $domain->domain_uuid)
             ->where('extension', $request->input('extension'))
             ->first();

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -91,5 +91,14 @@ class RouteServiceProvider extends ServiceProvider
             $key = $request->bearerToken() ?: (optional($request->user())->id ?: $request->ip());
             return Limit::perMinute(10)->by('call-flow-simulate:' . $key);
         });
+
+        // Machine-to-machine integration endpoints (e.g. the extension lookup)
+        // are an enumeration oracle (404 vs 200). Cap them so a leaked token
+        // can't be used to brute-force the extension/domain space. Keyed by
+        // bearer token, falling back to client IP.
+        RateLimiter::for('integrations', function (Request $request) {
+            $key = $request->bearerToken() ?: $request->ip();
+            return Limit::perMinute(30)->by('integrations:' . $key);
+        });
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -421,7 +421,10 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
 // Integration endpoints for external services (e.g. iqcrm) that authenticate
 // with a Sanctum personal access token. The api.token.auth middleware rejects
 // cookie/session requests so these routes are strictly machine-to-machine.
-Route::group(['middleware' => ['auth:sanctum', 'api.token.auth']], function () {
+// The 'integrations' throttle limiter caps these routes so a leaked token
+// can't be used as an enumeration oracle (404 vs 200) against the
+// extension/domain space.
+Route::group(['middleware' => ['auth:sanctum', 'api.token.auth', 'throttle:integrations']], function () {
     Route::get('/integrations/extensions/lookup', [ExtensionsController::class, 'lookupByNumber'])
         ->name('integrations.extensions.lookup');
     Route::post('/integrations/extensions/{extension}/push-token', [ExtensionsController::class, 'updatePushToken'])


### PR DESCRIPTION
Ports the security hardening from upstream PR nemerald-voip/fspbx#423 (added there during today's PR refresh) onto our production main, since the same unscoped endpoint is live here:

- `/api/integrations/extensions/lookup` previously let **any** valid Sanctum token resolve **any** extension in **any** domain. Tokens with a non-null `domain_uuid` are now scoped to their own domain (403 otherwise); global tokens (null `domain_uuid`) are unchanged.
- New `integrations` rate limiter (30/min, keyed by bearer token) on the whole machine-to-machine route group — it was an unthrottled enumeration oracle (404 vs 200).

Both production tokens (`iqcrm-api`, `iqportal-voxra`) are global tokens, so nothing breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)