### PR TITLE
Add Telnyx AI agents via provider abstraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,6 +159,13 @@ ELEVENLABS_API_KEY=
 ELEVENLABS_BASE_URL=https://api.elevenlabs.io
 ELEVENLABS_TIMEOUT=60
 
+# Telnyx AI agents. SIP attach is optional: leave the ATTACH_* vars empty to
+# bridge agents via their public assistant subdomain only. attach_domain must
+# equal the proxy host (Telnyx derives the registration realm from it).
+TELNYX_API_KEY=
+TELNYX_ATTACH_DOMAIN=
+TELNYX_ATTACH_PROXY=
+
 ### FS PBX - Laravel Reverb
 BROADCAST_CONNECTION=reverb
 REVERB_APP_ID=

--- a/app/Http/Controllers/AiAgentController.php
+++ b/app/Http/Controllers/AiAgentController.php
@@ -14,7 +14,9 @@ use Illuminate\Support\Facades\Storage;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\AllowedFilter;
 use App\Services\CallRoutingOptionsService;
+use App\Services\Convai\ConvaiProviderRegistry;
 use App\Services\ElevenLabsConvaiService;
+use App\Services\TelnyxConvaiService;
 use App\Services\Tts\ElevenLabsTtsService;
 use App\Http\Requests\StoreAiAgentRequest;
 use App\Http\Requests\UpdateAiAgentRequest;
@@ -67,6 +69,7 @@ class AiAgentController extends Controller
                 'agent_name',
                 'agent_extension',
                 'agent_enabled',
+                'provider',
                 'description',
             ])
             ->allowedFilters([
@@ -97,46 +100,19 @@ class AiAgentController extends Controller
         try {
             DB::beginTransaction();
 
-            $convaiService = app(ElevenLabsConvaiService::class);
+            $provider = app(ConvaiProviderRegistry::class)->resolve($inputs['provider'] ?? null);
+            $inputs = $this->normalizeProviderInputs($provider->name(), $inputs);
 
-            // Create the agent in ElevenLabs
-            $agentResponse = $convaiService->createAgent(
-                $inputs['agent_name'],
-                $inputs['system_prompt'] ?? null,
-                $inputs['first_message'] ?? null,
-                $inputs['voice_id'] ?? null,
-                $inputs['language'] ?? 'en',
-            );
-
-            $elevenlabsAgentId = $agentResponse['agent_id'] ?? null;
-            $elevenlabsPhoneNumberId = null;
-
-            // Create SIP trunk phone number and assign agent
-            if ($elevenlabsAgentId) {
-                try {
-                    $phoneResponse = $convaiService->createSipTrunkPhoneNumber(
-                        'Voxra Agent: ' . $inputs['agent_name'],
-                        $inputs['agent_extension'],
-                        config('services.elevenlabs.sip_allowed_addresses', []),
-                    );
-                    $elevenlabsPhoneNumberId = $phoneResponse['phone_number_id'] ?? null;
-
-                    if ($elevenlabsPhoneNumberId) {
-                        $convaiService->assignAgentToPhoneNumber($elevenlabsPhoneNumberId, $elevenlabsAgentId);
-                    }
-                } catch (\Exception $e) {
-                    logger('ElevenLabs SIP phone number setup warning: ' . $e->getMessage());
-                }
-            }
+            // Create the agent on the provider's platform
+            $providerAttributes = $provider->provisionAgent($inputs);
 
             $instance = $this->model;
-            $instance->fill([
+            $instance->fill(array_merge([
                 'domain_uuid' => session('domain_uuid'),
                 'dialplan_uuid' => Str::uuid(),
                 'agent_name' => $inputs['agent_name'],
                 'agent_extension' => $inputs['agent_extension'],
-                'elevenlabs_agent_id' => $elevenlabsAgentId,
-                'elevenlabs_phone_number_id' => $elevenlabsPhoneNumberId,
+                'provider' => $provider->name(),
                 'system_prompt' => $inputs['system_prompt'] ?? null,
                 'first_message' => $inputs['first_message'] ?? null,
                 'voice_id' => $inputs['voice_id'] ?? null,
@@ -145,7 +121,7 @@ class AiAgentController extends Controller
                 'description' => $inputs['description'] ?? null,
                 'insert_date' => date('Y-m-d H:i:s'),
                 'insert_user' => session('user_uuid'),
-            ]);
+            ], $providerAttributes));
 
             $instance->save();
 
@@ -181,22 +157,10 @@ class AiAgentController extends Controller
 
             $instance = $this->model::where('ai_agent_uuid', $inputs['ai_agent_uuid'])->firstOrFail();
 
-            // Update ElevenLabs agent if relevant fields changed
-            if ($instance->elevenlabs_agent_id) {
-                $convaiService = app(ElevenLabsConvaiService::class);
-                try {
-                    $convaiService->updateAgent(
-                        $instance->elevenlabs_agent_id,
-                        $inputs['agent_name'],
-                        $inputs['system_prompt'] ?? null,
-                        $inputs['first_message'] ?? null,
-                        $inputs['voice_id'] ?? null,
-                        $inputs['language'] ?? 'en',
-                    );
-                } catch (\Exception $e) {
-                    logger('ElevenLabs update agent warning: ' . $e->getMessage());
-                }
-            }
+            // Push updated settings to the agent's provider platform
+            $provider = app(ConvaiProviderRegistry::class)->resolve($instance->provider);
+            $inputs = $this->normalizeProviderInputs($provider->name(), $inputs);
+            $provider->updateAgent($instance, $inputs);
 
             $instance->fill([
                 'agent_name' => $inputs['agent_name'],
@@ -204,6 +168,7 @@ class AiAgentController extends Controller
                 'system_prompt' => $inputs['system_prompt'] ?? null,
                 'first_message' => $inputs['first_message'] ?? null,
                 'voice_id' => $inputs['voice_id'] ?? null,
+                'model' => $inputs['model'] ?? $instance->model,
                 'language' => $inputs['language'] ?? 'en',
                 'agent_enabled' => $inputs['agent_enabled'],
                 'description' => $inputs['description'] ?? null,
@@ -240,23 +205,17 @@ class AiAgentController extends Controller
         try {
             DB::beginTransaction();
 
-            $items = $this->model::whereIn('ai_agent_uuid', request('items'))
-                ->get(['ai_agent_uuid', 'dialplan_uuid', 'elevenlabs_agent_id', 'elevenlabs_phone_number_id']);
+            $items = $this->model::whereIn('ai_agent_uuid', request('items'))->get();
 
-            $convaiService = null;
-            try {
-                $convaiService = app(ElevenLabsConvaiService::class);
-            } catch (\Exception $e) {
-                logger('ElevenLabs service unavailable during delete: ' . $e->getMessage());
-            }
+            $registry = app(ConvaiProviderRegistry::class);
 
             foreach ($items as $item) {
                 // Clean up KB documents (ElevenLabs + local files + DB rows)
                 $kbDocs = AiAgentKbDocument::where('ai_agent_uuid', $item->ai_agent_uuid)->get();
                 foreach ($kbDocs as $kbDoc) {
-                    if ($convaiService && $kbDoc->elevenlabs_documentation_id) {
+                    if ($kbDoc->elevenlabs_documentation_id) {
                         try {
-                            $convaiService->deleteKbDocument($kbDoc->elevenlabs_documentation_id);
+                            app(ElevenLabsConvaiService::class)->deleteKbDocument($kbDoc->elevenlabs_documentation_id);
                         } catch (\Exception $e) {
                             logger('ElevenLabs KB cleanup warning: ' . $e->getMessage());
                         }
@@ -267,18 +226,11 @@ class AiAgentController extends Controller
                     $kbDoc->delete();
                 }
 
-                // Clean up ElevenLabs resources
-                if ($convaiService) {
-                    try {
-                        if ($item->elevenlabs_phone_number_id) {
-                            $convaiService->deletePhoneNumber($item->elevenlabs_phone_number_id);
-                        }
-                        if ($item->elevenlabs_agent_id) {
-                            $convaiService->deleteAgent($item->elevenlabs_agent_id);
-                        }
-                    } catch (\Exception $e) {
-                        logger('ElevenLabs cleanup warning: ' . $e->getMessage());
-                    }
+                // Clean up provider-side resources
+                try {
+                    $registry->resolve($item->provider)->deleteAgent($item);
+                } catch (\Exception $e) {
+                    logger('Convai provider cleanup warning: ' . $e->getMessage());
                 }
 
                 // Delete dialplan
@@ -306,14 +258,28 @@ class AiAgentController extends Controller
         }
     }
 
+    /**
+     * Map provider-specific form fields onto the canonical input keys.
+     */
+    private function normalizeProviderInputs(string $providerName, array $inputs): array
+    {
+        if ($providerName === AiAgent::PROVIDER_TELNYX && !empty($inputs['telnyx_voice_id'])) {
+            $inputs['voice_id'] = $inputs['telnyx_voice_id'];
+        }
+
+        return $inputs;
+    }
+
     private function generateDialPlanXML(AiAgent $agent): void
     {
-        $data = [
+        $provider = app(ConvaiProviderRegistry::class)->resolve($agent->provider);
+
+        $data = array_merge([
             'agent' => $agent,
             'dialplan_continue' => 'false',
-        ];
+        ], $provider->dialplanData($agent));
 
-        $xml = trim(view('layouts.xml.ai-agent-dial-plan-template', $data)->render());
+        $xml = trim(view($provider->dialplanView(), $data)->render());
 
         $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = false;
@@ -387,6 +353,19 @@ class AiAgentController extends Controller
                 logger('Failed to fetch ElevenLabs voices: ' . $e->getMessage());
             }
 
+            // Get Telnyx voices and models (only when the API key is configured)
+            $telnyxVoices = [];
+            $telnyxModels = [];
+            if ((string) config('services.telnyx.api_key', '') !== '') {
+                try {
+                    $telnyxService = app(TelnyxConvaiService::class);
+                    $telnyxVoices = $telnyxService->getVoices();
+                    $telnyxModels = $telnyxService->getModels();
+                } catch (\Exception $e) {
+                    logger('Failed to fetch Telnyx voices/models: ' . $e->getMessage());
+                }
+            }
+
             if ($itemUuid) {
                 $agent = $this->model::where('domain_uuid', $domainUuid)
                     ->where('ai_agent_uuid', $itemUuid)
@@ -428,6 +407,8 @@ class AiAgentController extends Controller
                 $agent->agent_name = '';
                 $agent->agent_extension = $agent->generateUniqueSequenceNumber();
                 $agent->description = '';
+                $agent->provider = AiAgent::PROVIDER_ELEVENLABS;
+                $agent->model = null;
                 $agent->system_prompt = '';
                 $agent->first_message = '';
                 $agent->voice_id = null;
@@ -462,7 +443,10 @@ class AiAgentController extends Controller
                 'permissions' => $permissions,
                 'routes' => $routes,
                 'routing_types' => $routingTypes,
+                'providers' => app(ConvaiProviderRegistry::class)->available(),
                 'voices' => $voices,
+                'telnyx_voices' => $telnyxVoices,
+                'telnyx_models' => $telnyxModels,
                 'languages' => $languages,
                 'kb_documents' => $kbDocuments,
             ]);

--- a/app/Http/Requests/StoreAiAgentRequest.php
+++ b/app/Http/Requests/StoreAiAgentRequest.php
@@ -23,10 +23,13 @@ class StoreAiAgentRequest extends FormRequest
                 new UniqueExtension(),
             ],
             'agent_enabled' => 'present',
+            'provider' => 'nullable|string|in:elevenlabs,telnyx',
+            'model' => 'nullable|string|max:100',
             'description' => 'nullable|string|max:255',
             'system_prompt' => 'nullable|string|max:5000',
             'first_message' => 'nullable|string|max:500',
             'voice_id' => 'nullable|string',
+            'telnyx_voice_id' => 'nullable|string',
             'language' => 'nullable|string|max:20',
         ];
     }

--- a/app/Http/Requests/UpdateAiAgentRequest.php
+++ b/app/Http/Requests/UpdateAiAgentRequest.php
@@ -24,10 +24,12 @@ class UpdateAiAgentRequest extends FormRequest
                 new UniqueExtension($this->route('ai_agent')),
             ],
             'agent_enabled' => 'present',
+            'model' => 'nullable|string|max:100',
             'description' => 'nullable|string|max:255',
             'system_prompt' => 'nullable|string|max:5000',
             'first_message' => 'nullable|string|max:500',
             'voice_id' => 'nullable|string',
+            'telnyx_voice_id' => 'nullable|string',
             'language' => 'nullable|string|max:20',
         ];
     }

--- a/app/Models/AiAgent.php
+++ b/app/Models/AiAgent.php
@@ -22,8 +22,14 @@ class AiAgent extends Model
         'dialplan_uuid',
         'agent_name',
         'agent_extension',
+        'provider',
+        'model',
         'elevenlabs_agent_id',
         'elevenlabs_phone_number_id',
+        'telnyx_assistant_id',
+        'telnyx_uac_connection_id',
+        'telnyx_attach_extension_uuid',
+        'telnyx_attach_extension',
         'system_prompt',
         'first_message',
         'voice_id',
@@ -46,6 +52,9 @@ class AiAgent extends Model
 
     public const MODE_DIRECT = 'direct';
     public const MODE_RECEPTION = 'reception';
+
+    public const PROVIDER_ELEVENLABS = 'elevenlabs';
+    public const PROVIDER_TELNYX = 'telnyx';
 
     public function scopeReception($query)
     {

--- a/app/Services/Convai/ConvaiProviderInterface.php
+++ b/app/Services/Convai/ConvaiProviderInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services\Convai;
+
+use App\Models\AiAgent;
+
+/**
+ * Common surface for conversational-AI agent providers (ElevenLabs, Telnyx).
+ *
+ * Providers own the remote-platform lifecycle of an agent; the controller
+ * owns the local row, the dialplan, and anything provider-specific beyond
+ * this interface (e.g. ElevenLabs knowledge base / reception tools).
+ */
+interface ConvaiProviderInterface
+{
+    /**
+     * Machine name, matches the `provider` column on v_ai_agents.
+     */
+    public function name(): string;
+
+    /**
+     * Create the agent on the remote platform plus any call-path resources
+     * (SIP trunk number, UAC connection, attach extension, ...).
+     *
+     * @param  array  $inputs  validated request inputs
+     * @return array  attributes to persist on the AiAgent row
+     */
+    public function provisionAgent(array $inputs): array;
+
+    /**
+     * Push updated settings to the remote platform. Best-effort; throw on
+     * hard failures only.
+     */
+    public function updateAgent(AiAgent $agent, array $inputs): void;
+
+    /**
+     * Tear down all remote resources for the agent.
+     */
+    public function deleteAgent(AiAgent $agent): void;
+
+    /**
+     * Blade view that renders the FreeSWITCH dialplan for this provider.
+     */
+    public function dialplanView(): string;
+
+    /**
+     * Extra data the dialplan view needs beyond ['agent' => ...].
+     */
+    public function dialplanData(AiAgent $agent): array;
+}

--- a/app/Services/Convai/ConvaiProviderRegistry.php
+++ b/app/Services/Convai/ConvaiProviderRegistry.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services\Convai;
+
+use RuntimeException;
+
+class ConvaiProviderRegistry
+{
+    public const DEFAULT = 'elevenlabs';
+
+    /** @var array<string, class-string<ConvaiProviderInterface>> */
+    private const PROVIDERS = [
+        'elevenlabs' => ElevenLabsConvaiProvider::class,
+        'telnyx'     => TelnyxConvaiProvider::class,
+    ];
+
+    public function resolve(?string $name): ConvaiProviderInterface
+    {
+        $name = $name ?: self::DEFAULT;
+
+        if (!isset(self::PROVIDERS[$name])) {
+            throw new RuntimeException("Unknown conversational AI provider: {$name}");
+        }
+
+        return app(self::PROVIDERS[$name]);
+    }
+
+    /**
+     * Providers available for new agents, for the UI.
+     * A provider is offered only when its API key is configured.
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public function available(): array
+    {
+        $options = [];
+
+        if ((string) config('services.elevenlabs.api_key', '') !== '') {
+            $options[] = ['value' => 'elevenlabs', 'label' => 'ElevenLabs'];
+        }
+        if ((string) config('services.telnyx.api_key', '') !== '') {
+            $options[] = ['value' => 'telnyx', 'label' => 'Telnyx'];
+        }
+
+        return $options;
+    }
+}

--- a/app/Services/Convai/ElevenLabsConvaiProvider.php
+++ b/app/Services/Convai/ElevenLabsConvaiProvider.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Services\Convai;
+
+use App\Models\AiAgent;
+use App\Services\ElevenLabsConvaiService;
+
+/**
+ * Adapter exposing the existing ElevenLabsConvaiService through the
+ * provider interface. Call path: the PBX dialplan bridges to the agent's
+ * ElevenLabs SIP trunk number at sip.rtc.elevenlabs.io.
+ */
+class ElevenLabsConvaiProvider implements ConvaiProviderInterface
+{
+    public function __construct(private ElevenLabsConvaiService $service)
+    {
+    }
+
+    public function name(): string
+    {
+        return 'elevenlabs';
+    }
+
+    public function provisionAgent(array $inputs): array
+    {
+        $agentResponse = $this->service->createAgent(
+            $inputs['agent_name'],
+            $inputs['system_prompt'] ?? null,
+            $inputs['first_message'] ?? null,
+            $inputs['voice_id'] ?? null,
+            $inputs['language'] ?? 'en',
+        );
+
+        $elevenlabsAgentId = $agentResponse['agent_id'] ?? null;
+        $elevenlabsPhoneNumberId = null;
+
+        // Create SIP trunk phone number and assign agent
+        if ($elevenlabsAgentId) {
+            try {
+                $phoneResponse = $this->service->createSipTrunkPhoneNumber(
+                    'Voxra Agent: ' . $inputs['agent_name'],
+                    $inputs['agent_extension'],
+                    config('services.elevenlabs.sip_allowed_addresses', []),
+                );
+                $elevenlabsPhoneNumberId = $phoneResponse['phone_number_id'] ?? null;
+
+                if ($elevenlabsPhoneNumberId) {
+                    $this->service->assignAgentToPhoneNumber($elevenlabsPhoneNumberId, $elevenlabsAgentId);
+                }
+            } catch (\Exception $e) {
+                logger('ElevenLabs SIP phone number setup warning: ' . $e->getMessage());
+            }
+        }
+
+        return [
+            'elevenlabs_agent_id' => $elevenlabsAgentId,
+            'elevenlabs_phone_number_id' => $elevenlabsPhoneNumberId,
+        ];
+    }
+
+    public function updateAgent(AiAgent $agent, array $inputs): void
+    {
+        if (!$agent->elevenlabs_agent_id) {
+            return;
+        }
+
+        try {
+            $this->service->updateAgent(
+                $agent->elevenlabs_agent_id,
+                $inputs['agent_name'],
+                $inputs['system_prompt'] ?? null,
+                $inputs['first_message'] ?? null,
+                $inputs['voice_id'] ?? null,
+                $inputs['language'] ?? 'en',
+            );
+        } catch (\Exception $e) {
+            logger('ElevenLabs update agent warning: ' . $e->getMessage());
+        }
+    }
+
+    public function deleteAgent(AiAgent $agent): void
+    {
+        if ($agent->elevenlabs_phone_number_id) {
+            $this->service->deletePhoneNumber($agent->elevenlabs_phone_number_id);
+        }
+        if ($agent->elevenlabs_agent_id) {
+            $this->service->deleteAgent($agent->elevenlabs_agent_id);
+        }
+    }
+
+    public function dialplanView(): string
+    {
+        return 'layouts.xml.ai-agent-dial-plan-template';
+    }
+
+    public function dialplanData(AiAgent $agent): array
+    {
+        return [];
+    }
+}

--- a/app/Services/Convai/TelnyxConvaiProvider.php
+++ b/app/Services/Convai/TelnyxConvaiProvider.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Services\Convai;
+
+use App\Models\AiAgent;
+use App\Models\Domain;
+use App\Models\Extensions;
+use App\Models\FusionCache;
+use App\Services\TelnyxConvaiService;
+use RuntimeException;
+
+/**
+ * Telnyx AI assistant provider.
+ *
+ * Call path: SIP attach. A UAC connection makes Telnyx register into the
+ * PBX as an extension in a dedicated attach domain (the domain name must
+ * match the proxy host Telnyx is given, because Telnyx derives the AOR
+ * domain from the proxy). The tenant dialplan bridges to that registered
+ * extension and falls back to the assistant's public SIP subdomain
+ * (assistant-<id>.sip.telnyx.com, reachable without registration) when the
+ * registration is down.
+ *
+ * When TELNYX_ATTACH_DOMAIN / TELNYX_ATTACH_PROXY are not configured the
+ * provider skips SIP attach and the dialplan uses the subdomain bridge only.
+ */
+class TelnyxConvaiProvider implements ConvaiProviderInterface
+{
+    public function __construct(private TelnyxConvaiService $service)
+    {
+    }
+
+    public function name(): string
+    {
+        return 'telnyx';
+    }
+
+    public function provisionAgent(array $inputs): array
+    {
+        $assistant = $this->service->createAssistant(
+            $inputs['agent_name'],
+            $inputs['system_prompt'] ?? null,
+            $inputs['first_message'] ?? null,
+            $inputs['voice_id'] ?? null,
+            $inputs['model'] ?? null,
+            $inputs['language'] ?? 'en',
+        );
+
+        $assistantId = $assistant['id'] ?? null;
+        if (!$assistantId) {
+            throw new RuntimeException('Telnyx did not return an assistant id.');
+        }
+
+        $attributes = [
+            'telnyx_assistant_id' => $assistantId,
+            'model' => $inputs['model'] ?? null,
+        ];
+
+        // SIP attach is best-effort: the subdomain bridge in the dialplan
+        // works without it, so a failure here must not lose the assistant.
+        try {
+            $attributes = array_merge($attributes, $this->provisionSipAttach($assistantId, $inputs['agent_name']));
+        } catch (\Exception $e) {
+            logger('Telnyx SIP attach setup warning: ' . $e->getMessage());
+        }
+
+        return $attributes;
+    }
+
+    public function updateAgent(AiAgent $agent, array $inputs): void
+    {
+        if (!$agent->telnyx_assistant_id) {
+            return;
+        }
+
+        try {
+            $this->service->updateAssistant(
+                $agent->telnyx_assistant_id,
+                $inputs['agent_name'],
+                $inputs['system_prompt'] ?? null,
+                $inputs['first_message'] ?? null,
+                $inputs['voice_id'] ?? null,
+                $inputs['model'] ?? $agent->model,
+                $inputs['language'] ?? 'en',
+            );
+        } catch (\Exception $e) {
+            logger('Telnyx update assistant warning: ' . $e->getMessage());
+        }
+    }
+
+    public function deleteAgent(AiAgent $agent): void
+    {
+        if ($agent->telnyx_uac_connection_id) {
+            $this->service->deleteUacConnection($agent->telnyx_uac_connection_id);
+        }
+        if ($agent->telnyx_assistant_id) {
+            $this->service->deleteAssistant($agent->telnyx_assistant_id);
+        }
+        if ($agent->telnyx_attach_extension_uuid) {
+            $extension = Extensions::where('extension_uuid', $agent->telnyx_attach_extension_uuid)->first();
+            if ($extension) {
+                FusionCache::clear('directory:' . $extension->extension . '@' . $extension->user_context);
+                $extension->delete();
+            }
+        }
+    }
+
+    public function dialplanView(): string
+    {
+        return 'layouts.xml.telnyx-ai-agent-dial-plan-template';
+    }
+
+    public function dialplanData(AiAgent $agent): array
+    {
+        return [
+            'attach_domain' => (string) config('services.telnyx.attach_domain', ''),
+        ];
+    }
+
+    /**
+     * Create the attach extension + UAC connection so Telnyx registers in.
+     *
+     * @return array attributes to persist on the AiAgent row
+     */
+    private function provisionSipAttach(string $assistantId, string $agentName): array
+    {
+        $attachDomainName = (string) config('services.telnyx.attach_domain', '');
+        $attachProxy = (string) config('services.telnyx.attach_proxy', '');
+
+        if ($attachDomainName === '' || $attachProxy === '') {
+            logger('Telnyx SIP attach skipped: TELNYX_ATTACH_DOMAIN / TELNYX_ATTACH_PROXY not configured.');
+            return [];
+        }
+
+        $attachDomain = $this->findOrCreateAttachDomain($attachDomainName);
+        $attachExtension = $this->generateAttachExtension($attachDomain->domain_uuid);
+        $password = bin2hex(random_bytes(16));
+
+        $extension = new Extensions();
+        $extension->fill([
+            'domain_uuid' => $attachDomain->domain_uuid,
+            'extension' => $attachExtension,
+            'password' => $password,
+            'user_context' => $attachDomainName,
+            'enabled' => 'true',
+            'effective_caller_id_name' => 'Telnyx Agent: ' . $agentName,
+            'effective_caller_id_number' => $attachExtension,
+            'call_timeout' => 30,
+            'description' => 'Telnyx SIP attach for assistant ' . $assistantId,
+        ]);
+        $extension->save();
+
+        FusionCache::clear('directory:' . $attachExtension . '@' . $attachDomainName);
+
+        try {
+            $connection = $this->service->createUacConnection(
+                'voxra-agent-' . $attachExtension,
+                $attachExtension,
+                $password,
+                $attachProxy,
+                // assistant ids already carry the "assistant-" prefix
+                'agent@' . $assistantId . '.sip.telnyx.com',
+            );
+        } catch (\Exception $e) {
+            // Don't leave an orphaned credentialed extension behind.
+            $extension->delete();
+            FusionCache::clear('directory:' . $attachExtension . '@' . $attachDomainName);
+            throw $e;
+        }
+
+        return [
+            'telnyx_uac_connection_id' => $connection['data']['id'] ?? null,
+            'telnyx_attach_extension_uuid' => $extension->extension_uuid,
+            'telnyx_attach_extension' => $attachExtension,
+        ];
+    }
+
+    private function findOrCreateAttachDomain(string $domainName): Domain
+    {
+        $domain = Domain::where('domain_name', $domainName)->first();
+
+        if (!$domain) {
+            $domain = new Domain();
+            $domain->domain_name = $domainName;
+            $domain->domain_enabled = 'true';
+            $domain->domain_description = 'Telnyx SIP attach registrations (system)';
+            $domain->save();
+        }
+
+        return $domain;
+    }
+
+    /**
+     * Unique numeric SIP username in the shared attach domain. Uses an
+     * 8-digit number outside any tenant dial range.
+     */
+    private function generateAttachExtension(string $attachDomainUuid): string
+    {
+        for ($i = 0; $i < 25; $i++) {
+            $candidate = (string) random_int(80000000, 89999999);
+            $exists = Extensions::where('domain_uuid', $attachDomainUuid)
+                ->where('extension', $candidate)
+                ->exists();
+            if (!$exists) {
+                return $candidate;
+            }
+        }
+
+        throw new RuntimeException('Unable to allocate a unique Telnyx attach extension.');
+    }
+}

--- a/app/Services/TelnyxConvaiService.php
+++ b/app/Services/TelnyxConvaiService.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace App\Services;
+
+use RuntimeException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\ConnectionException;
+
+/**
+ * Thin client for the Telnyx AI assistant + SIP attach (UAC connection) APIs.
+ *
+ * Every Telnyx AI assistant auto-creates a TeXML app with a SIP subdomain
+ * `assistant-<id>.sip.telnyx.com` that accepts INVITEs from anyone, so the
+ * PBX can always bridge to the agent without registration. SIP attach (a UAC
+ * connection) additionally makes Telnyx register INTO the PBX as a SIP
+ * endpoint; calls to the registered extension reach the assistant.
+ */
+class TelnyxConvaiService
+{
+    private string $apiKey;
+    private string $baseUrl;
+    private int $timeout;
+
+    public function __construct()
+    {
+        $this->apiKey  = (string) config('services.telnyx.api_key', '');
+        $this->baseUrl = rtrim((string) config('services.telnyx.base_url', 'https://api.telnyx.com'), '/');
+        $this->timeout = (int) config('services.telnyx.timeout', 60);
+
+        if ($this->apiKey === '') {
+            throw new RuntimeException('Telnyx API key is not configured. Please set TELNYX_API_KEY in your environment file.');
+        }
+    }
+
+    /**
+     * Create a new Telnyx AI assistant.
+     * POST /v2/ai/assistants
+     */
+    public function createAssistant(string $name, ?string $instructions, ?string $greeting, ?string $voice, ?string $model, string $language = 'en'): array
+    {
+        $body = array_filter([
+            'name'         => $name,
+            'instructions' => $instructions ?? '',
+            'greeting'     => $greeting ?? '',
+            'model'        => $model,
+            'voice_settings' => $voice ? ['voice' => $voice] : null,
+            'transcription'  => ['language' => $language],
+        ], fn ($v) => $v !== null);
+
+        $response = $this->http()->post('v2/ai/assistants', $body);
+
+        if (!$response->successful()) {
+            logger('Telnyx create assistant error: ' . $response->body());
+            throw new RuntimeException('Failed to create Telnyx assistant: ' . $this->errorDetail($response));
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Update an existing Telnyx assistant.
+     * POST /v2/ai/assistants/{assistant_id}
+     */
+    public function updateAssistant(string $assistantId, ?string $name, ?string $instructions, ?string $greeting, ?string $voice, ?string $model, string $language = 'en'): array
+    {
+        $body = array_filter([
+            'name'         => $name,
+            'instructions' => $instructions ?? '',
+            'greeting'     => $greeting ?? '',
+            'model'        => $model,
+            'voice_settings' => $voice ? ['voice' => $voice] : null,
+            'transcription'  => ['language' => $language],
+        ], fn ($v) => $v !== null);
+
+        $response = $this->http()->post("v2/ai/assistants/{$assistantId}", $body);
+
+        if (!$response->successful()) {
+            logger('Telnyx update assistant error: ' . $response->body());
+            throw new RuntimeException('Failed to update Telnyx assistant: ' . $this->errorDetail($response));
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Delete a Telnyx assistant.
+     * DELETE /v2/ai/assistants/{assistant_id}
+     */
+    public function deleteAssistant(string $assistantId): void
+    {
+        $response = $this->http()->delete("v2/ai/assistants/{$assistantId}");
+
+        if (!$response->successful() && $response->status() !== 404) {
+            logger('Telnyx delete assistant error: ' . $response->body());
+            throw new RuntimeException('Failed to delete Telnyx assistant: ' . $this->errorDetail($response));
+        }
+    }
+
+    /**
+     * Create a SIP attach (UAC) connection so Telnyx registers into the PBX.
+     * POST /v2/uac_connections
+     *
+     * Telnyx quirks (verified 2026-06):
+     *  - the AOR/realm domain is taken from the proxy host, so the PBX must
+     *    have a directory domain whose name matches `proxy` (without port)
+     *  - `outbound_proxy` requires a `sip:` scheme if used
+     *  - the registration prober starts ~4-5 minutes after create/toggle
+     *  - `expiration_sec` is not honoured reliably
+     */
+    public function createUacConnection(string $connectionName, string $username, string $password, string $proxy, string $destinationUri): array
+    {
+        $body = [
+            'connection_name' => $connectionName,
+            'active' => true,
+            'external_uac_settings' => [
+                'username'       => $username,
+                'password'       => $password,
+                'proxy'          => $proxy,
+                'transport'      => 'UDP',
+                'expiration_sec' => 300,
+            ],
+            'internal_uac_settings' => [
+                'destination_uri' => $destinationUri,
+            ],
+        ];
+
+        $response = $this->http()->post('v2/uac_connections', $body);
+
+        if (!$response->successful()) {
+            logger('Telnyx create UAC connection error: ' . $response->body());
+            throw new RuntimeException('Failed to create Telnyx UAC connection: ' . $this->errorDetail($response));
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Delete a UAC connection.
+     * DELETE /v2/uac_connections/{id}
+     */
+    public function deleteUacConnection(string $connectionId): void
+    {
+        $response = $this->http()->delete("v2/uac_connections/{$connectionId}");
+
+        if (!$response->successful() && $response->status() !== 404) {
+            logger('Telnyx delete UAC connection error: ' . $response->body());
+            throw new RuntimeException('Failed to delete Telnyx UAC connection: ' . $this->errorDetail($response));
+        }
+    }
+
+    /**
+     * List Telnyx-native TTS voices for the UI.
+     * GET /v2/text-to-speech/voices
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public function getVoices(): array
+    {
+        $response = $this->http()->get('v2/text-to-speech/voices', ['provider' => 'telnyx']);
+
+        if (!$response->successful()) {
+            logger('Telnyx list voices error: ' . $response->body());
+            return [];
+        }
+
+        return collect($response->json('voices', []))
+            ->filter(fn ($v) => !empty($v['id']))
+            ->map(fn ($v) => [
+                'value' => $v['id'],
+                'label' => trim(($v['name'] ?? $v['id']) . ' (' . ($v['language'] ?? '') . ($v['gender'] ? ', ' . $v['gender'] : '') . ')'),
+            ])
+            ->values()
+            ->toArray();
+    }
+
+    /**
+     * List available LLM models for the UI.
+     * GET /v2/ai/models
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public function getModels(): array
+    {
+        $response = $this->http()->get('v2/ai/models');
+
+        if (!$response->successful()) {
+            logger('Telnyx list models error: ' . $response->body());
+            return [];
+        }
+
+        return collect($response->json('data', []))
+            ->filter(fn ($m) => !empty($m['id']))
+            ->map(fn ($m) => ['value' => $m['id'], 'label' => $m['id']])
+            ->values()
+            ->toArray();
+    }
+
+    private function errorDetail(\Illuminate\Http\Client\Response $response): string
+    {
+        $errors = $response->json('errors');
+        if (is_array($errors) && !empty($errors)) {
+            return collect($errors)
+                ->map(fn ($e) => trim(($e['title'] ?? '') . ': ' . ($e['detail'] ?? '')))
+                ->implode('; ');
+        }
+
+        return $response->body();
+    }
+
+    private function http(): \Illuminate\Http\Client\PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl . '/')
+            ->timeout($this->timeout)
+            ->withToken($this->apiKey)
+            ->withHeaders([
+                'Content-Type' => 'application/json',
+                'Accept'       => 'application/json',
+            ])
+            ->retry(
+                3,
+                500,
+                function ($exception) {
+                    if ($exception instanceof ConnectionException) {
+                        return true;
+                    }
+                    $response = method_exists($exception, 'response') ? $exception->response() : null;
+                    $status = $response?->status();
+                    return in_array($status, [429, 500, 502, 503, 504], true);
+                },
+                throw: false
+            );
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -101,6 +101,22 @@ return [
         ))),
     ],
 
+    'telnyx' => [
+        'api_key'  => env('TELNYX_API_KEY', ''),
+        'base_url' => env('TELNYX_BASE_URL', 'https://api.telnyx.com'),
+        'timeout'  => (int) env('TELNYX_TIMEOUT', 60),
+        // SIP attach: Telnyx derives the registration AOR/realm from the proxy
+        // host, so attach_domain must be a FusionPBX directory domain whose
+        // name matches the proxy host below (it is auto-created on first use).
+        // Leave both empty to disable SIP attach; agents then use the public
+        // assistant subdomain bridge only.
+        // e.g. TELNYX_ATTACH_DOMAIN=172.236.17.39
+        'attach_domain' => env('TELNYX_ATTACH_DOMAIN', ''),
+        // Proxy advertised to Telnyx for UAC registration, host[:port].
+        // Must resolve to / be this PBX. e.g. TELNYX_ATTACH_PROXY=172.236.17.39:5060
+        'attach_proxy' => env('TELNYX_ATTACH_PROXY', ''),
+    ],
+
     'keygen' => [
         'api_url' => env('KEYGEN_API_URL', 'https://api.keygen.sh'),
         'account_id' => env('KEYGEN_ACCOUNT_ID', 'f2ca6242-a55c-4949-9529-d7d591d3271a'),

--- a/database/migrations/2026_06_07_000001_add_provider_columns_to_v_ai_agents.php
+++ b/database/migrations/2026_06_07_000001_add_provider_columns_to_v_ai_agents.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('v_ai_agents', function (Blueprint $table) {
+            if (!Schema::hasColumn('v_ai_agents', 'provider')) {
+                $table->string('provider', 20)->default('elevenlabs');
+            }
+            if (!Schema::hasColumn('v_ai_agents', 'model')) {
+                $table->string('model', 100)->nullable();
+            }
+            if (!Schema::hasColumn('v_ai_agents', 'telnyx_assistant_id')) {
+                $table->string('telnyx_assistant_id', 255)->nullable();
+            }
+            if (!Schema::hasColumn('v_ai_agents', 'telnyx_uac_connection_id')) {
+                $table->string('telnyx_uac_connection_id', 255)->nullable();
+            }
+            if (!Schema::hasColumn('v_ai_agents', 'telnyx_attach_extension_uuid')) {
+                $table->uuid('telnyx_attach_extension_uuid')->nullable();
+            }
+            if (!Schema::hasColumn('v_ai_agents', 'telnyx_attach_extension')) {
+                $table->string('telnyx_attach_extension', 20)->nullable();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('v_ai_agents', function (Blueprint $table) {
+            $table->dropColumn([
+                'provider',
+                'model',
+                'telnyx_assistant_id',
+                'telnyx_uac_connection_id',
+                'telnyx_attach_extension_uuid',
+                'telnyx_attach_extension',
+            ]);
+        });
+    }
+};

--- a/resources/js/Pages/AiAgents.vue
+++ b/resources/js/Pages/AiAgents.vue
@@ -44,6 +44,8 @@
                 </TableColumnHeader>
                 <TableColumnHeader header="Extension"
                     class="px-2 py-3.5 text-left text-sm font-semibold text-gray-900" />
+                <TableColumnHeader header="Provider"
+                    class="px-2 py-3.5 text-left text-sm font-semibold text-gray-900" />
                 <TableColumnHeader header="Description"
                     class="px-2 py-3.5 text-left text-sm font-semibold text-gray-900" />
                 <TableColumnHeader header="Status" class="px-2 py-3.5 text-left text-sm font-semibold text-gray-900" />
@@ -84,6 +86,12 @@
 
                     <TableField class="whitespace-nowrap px-2 py-2 text-sm text-gray-500"
                         :text="row.agent_extension" />
+                    <TableField class="whitespace-nowrap px-2 py-2 text-sm text-gray-500" :text="row.provider">
+                        <Badge v-if="row.provider === 'telnyx'" text="Telnyx" backgroundColor="bg-emerald-50"
+                            textColor="text-emerald-700" ringColor="ring-emerald-600/20" />
+                        <Badge v-else text="ElevenLabs" backgroundColor="bg-indigo-50" textColor="text-indigo-700"
+                            ringColor="ring-indigo-600/20" />
+                    </TableField>
                     <TableField class="whitespace-nowrap px-2 py-2 text-sm text-gray-500"
                         :text="row.description" />
                     <TableField class="whitespace-nowrap px-2 py-2 text-sm text-gray-500" :text="row.agent_enabled">

--- a/resources/js/Pages/components/forms/CreateAiAgentForm.vue
+++ b/resources/js/Pages/components/forms/CreateAiAgentForm.vue
@@ -56,6 +56,19 @@
 
                                             <HiddenElement name="agent_enabled" :meta="true" default="true" />
 
+                                            <SelectElement name="provider" :items="providerOptions"
+                                                :native="false" label="Provider"
+                                                :can-clear="false" :can-deselect="false"
+                                                description="Platform that runs this AI agent."
+                                                :columns="{ sm: { container: 6 } }" />
+
+                                            <SelectElement name="model" :items="telnyxModelOptions"
+                                                :search="true" :native="false" label="Model"
+                                                input-type="search" autocomplete="off"
+                                                placeholder="Choose a model"
+                                                :conditions="[['provider', 'telnyx']]"
+                                                :columns="{ sm: { container: 6 } }" />
+
                                             <TextElement name="agent_name" label="Name"
                                                 placeholder="e.g. Customer Support Agent"
                                                 :columns="{ sm: { container: 6 } }" />
@@ -80,6 +93,14 @@
                                                 :search="true" :native="false" label="Voice"
                                                 input-type="search" autocomplete="off"
                                                 placeholder="Choose a voice"
+                                                :conditions="[['provider', 'elevenlabs']]"
+                                                :columns="{ sm: { container: 6 } }" />
+
+                                            <SelectElement name="telnyx_voice_id" :items="telnyxVoiceOptions"
+                                                :search="true" :native="false" label="Voice"
+                                                input-type="search" autocomplete="off"
+                                                placeholder="Choose a voice"
+                                                :conditions="[['provider', 'telnyx']]"
                                                 :columns="{ sm: { container: 6 } }" />
 
                                             <SelectElement name="language" :items="languageOptions"
@@ -128,6 +149,28 @@ const voiceOptions = computed(() => {
     }, {});
 });
 
+const providerOptions = computed(() => {
+    const providers = props.options?.providers ?? [{ value: 'elevenlabs', label: 'ElevenLabs' }];
+    return providers.reduce((acc, p) => {
+        acc[p.value] = p.label;
+        return acc;
+    }, {});
+});
+
+const telnyxVoiceOptions = computed(() => {
+    return (props.options?.telnyx_voices ?? []).reduce((acc, voice) => {
+        acc[voice.value] = voice.label;
+        return acc;
+    }, {});
+});
+
+const telnyxModelOptions = computed(() => {
+    return (props.options?.telnyx_models ?? []).reduce((acc, model) => {
+        acc[model.value] = model.label;
+        return acc;
+    }, {});
+});
+
 const languageOptions = computed(() => {
     return (props.options?.languages ?? []).reduce((acc, lang) => {
         acc[lang.value] = lang.label;
@@ -140,9 +183,12 @@ const defaultFormData = computed(() => ({
     agent_extension: props.options?.item?.agent_extension ?? '',
     description: props.options?.item?.description ?? '',
     agent_enabled: props.options?.item?.agent_enabled ?? 'true',
+    provider: props.options?.item?.provider ?? (props.options?.providers?.[0]?.value ?? 'elevenlabs'),
+    model: props.options?.item?.model ?? null,
     system_prompt: props.options?.item?.system_prompt ?? '',
     first_message: props.options?.item?.first_message ?? '',
     voice_id: props.options?.item?.voice_id ?? null,
+    telnyx_voice_id: null,
     language: props.options?.item?.language ?? 'en',
 }));
 

--- a/resources/js/Pages/components/forms/UpdateAiAgentForm.vue
+++ b/resources/js/Pages/components/forms/UpdateAiAgentForm.vue
@@ -55,9 +55,20 @@
                                                 description="Configure the settings for this AI agent." />
 
                                             <HiddenElement name="ai_agent_uuid" />
+                                            <HiddenElement name="provider" :meta="true" />
 
                                             <ToggleElement name="agent_enabled" label="Enabled"
                                                 true-value="true" false-value="false" />
+
+                                            <StaticElement name="provider_label" tag="p"
+                                                :content="'Provider: ' + providerLabel" />
+
+                                            <SelectElement name="model" :items="telnyxModelOptions"
+                                                :search="true" :native="false" label="Model"
+                                                input-type="search" autocomplete="off"
+                                                placeholder="Choose a model"
+                                                :conditions="[['provider', 'telnyx']]"
+                                                :columns="{ sm: { container: 6 } }" />
 
                                             <TextElement name="agent_name" label="Name"
                                                 placeholder="e.g. Customer Support Agent"
@@ -83,6 +94,14 @@
                                                 :search="true" :native="false" label="Voice"
                                                 input-type="search" autocomplete="off"
                                                 placeholder="Choose a voice"
+                                                :conditions="[['provider', 'elevenlabs']]"
+                                                :columns="{ sm: { container: 6 } }" />
+
+                                            <SelectElement name="telnyx_voice_id" :items="telnyxVoiceOptions"
+                                                :search="true" :native="false" label="Voice"
+                                                input-type="search" autocomplete="off"
+                                                placeholder="Choose a voice"
+                                                :conditions="[['provider', 'telnyx']]"
                                                 :columns="{ sm: { container: 6 } }" />
 
                                             <SelectElement name="language" :items="languageOptions"
@@ -98,7 +117,7 @@
                                 </template>
                             </Vueform>
 
-                            <div v-if="!loading" class="mt-6 space-y-4 text-gray-600 bg-gray-50 px-4 py-6 sm:p-6 shadow sm:rounded-md">
+                            <div v-if="!loading && props.options?.item?.provider !== 'telnyx'" class="mt-6 space-y-4 text-gray-600 bg-gray-50 px-4 py-6 sm:p-6 shadow sm:rounded-md">
                                 <div>
                                     <h4 class="text-base font-semibold text-gray-900">Knowledge Base</h4>
                                     <p class="text-sm text-gray-500">Upload files, add URLs, or paste text. The agent will be able to reference these in conversations.</p>
@@ -201,6 +220,26 @@ const voiceOptions = computed(() => {
     }, {});
 });
 
+const providerLabel = computed(() => {
+    const provider = props.options?.item?.provider ?? 'elevenlabs';
+    const match = (props.options?.providers ?? []).find(p => p.value === provider);
+    return match?.label ?? provider;
+});
+
+const telnyxVoiceOptions = computed(() => {
+    return (props.options?.telnyx_voices ?? []).reduce((acc, voice) => {
+        acc[voice.value] = voice.label;
+        return acc;
+    }, {});
+});
+
+const telnyxModelOptions = computed(() => {
+    return (props.options?.telnyx_models ?? []).reduce((acc, model) => {
+        acc[model.value] = model.label;
+        return acc;
+    }, {});
+});
+
 const languageOptions = computed(() => {
     return (props.options?.languages ?? []).reduce((acc, lang) => {
         acc[lang.value] = lang.label;
@@ -208,17 +247,26 @@ const languageOptions = computed(() => {
     }, {});
 });
 
-const defaultFormData = computed(() => ({
-    ai_agent_uuid: props.options?.item?.ai_agent_uuid ?? '',
-    agent_name: props.options?.item?.agent_name ?? '',
-    agent_extension: props.options?.item?.agent_extension ?? '',
-    description: props.options?.item?.description ?? '',
-    agent_enabled: props.options?.item?.agent_enabled ?? 'true',
-    system_prompt: props.options?.item?.system_prompt ?? '',
-    first_message: props.options?.item?.first_message ?? '',
-    voice_id: props.options?.item?.voice_id ?? null,
-    language: props.options?.item?.language ?? 'en',
-}));
+const defaultFormData = computed(() => {
+    const provider = props.options?.item?.provider ?? 'elevenlabs';
+    const voiceId = props.options?.item?.voice_id ?? null;
+
+    return {
+        ai_agent_uuid: props.options?.item?.ai_agent_uuid ?? '',
+        agent_name: props.options?.item?.agent_name ?? '',
+        agent_extension: props.options?.item?.agent_extension ?? '',
+        description: props.options?.item?.description ?? '',
+        agent_enabled: props.options?.item?.agent_enabled ?? 'true',
+        provider: provider,
+        model: props.options?.item?.model ?? null,
+        system_prompt: props.options?.item?.system_prompt ?? '',
+        first_message: props.options?.item?.first_message ?? '',
+        // voice_id column stores whichever provider's voice is in use
+        voice_id: provider === 'telnyx' ? null : voiceId,
+        telnyx_voice_id: provider === 'telnyx' ? voiceId : null,
+        language: props.options?.item?.language ?? 'en',
+    };
+});
 
 const submitForm = async (FormData, form$) => {
     const requestData = form$.requestData;

--- a/resources/views/layouts/xml/telnyx-ai-agent-dial-plan-template.blade.php
+++ b/resources/views/layouts/xml/telnyx-ai-agent-dial-plan-template.blade.php
@@ -1,0 +1,19 @@
+<extension name="{{ $agent->agent_name }}" continue="{{ $dialplan_continue }}" uuid="{{ $agent->dialplan_uuid }}">
+    <condition field="destination_number" expression="^{{ $agent->agent_extension }}$">
+        <action application="ring_ready" data="" />
+        <action application="answer" data="" />
+        <action application="sleep" data="1000" />
+        <action application="set" data="hangup_after_bridge=true" />
+        <action application="set" data="absolute_codec_string=PCMU,PCMA" />
+        <action application="set" data="ringback=$${uk-ring}" />
+        <action application="set" data="transfer_ringback=$${uk-ring}" />
+        <action application="set" data="ignore_early_media=true" />
+        <action application="set" data="ai_agent_uuid={{ $agent->ai_agent_uuid }}" />
+@if (!empty($agent->telnyx_attach_extension) && !empty($attach_domain))
+        {{-- SIP attach: Telnyx registers this extension into the attach domain.
+             Falls through to the public assistant subdomain if unregistered. --}}
+        <action application="bridge" data="user/{{ $agent->telnyx_attach_extension }}@{{ $attach_domain }}" />
+@endif
+        <action application="bridge" data="sofia/external/sip:agent@{{ $agent->telnyx_assistant_id }}.sip.telnyx.com" />
+    </condition>
+</extension>


### PR DESCRIPTION
## Summary

Adds Telnyx AI assistants as a second conversational-AI agent provider alongside ElevenLabs, behind a new provider abstraction. A Telnyx agent is created from the same `/ai-agents` UI: pick **Telnyx** in the new provider selector, choose an LLM model and voice, and the agent gets an extension in the tenant domain exactly like ElevenLabs agents do.

## Architecture

- **`ConvaiProviderInterface` + `ConvaiProviderRegistry`** (`app/Services/Convai/`) — providers own the remote platform lifecycle (provision / update / delete) and supply their dialplan template. The controller stays provider-agnostic.
- **`ElevenLabsConvaiProvider`** — adapter over the existing `ElevenLabsConvaiService`; ElevenLabs behaviour is unchanged (incl. knowledge base + reception tools, which stay ElevenLabs-only).
- **`TelnyxConvaiService` + `TelnyxConvaiProvider`** — Telnyx assistants CRUD (`/v2/ai/assistants`), SIP attach (UAC connection) provisioning, voice/model catalogues.

## Telnyx call path

Primary: **SIP attach** — a Telnyx UAC connection registers into a dedicated attach domain on the PBX (Telnyx derives the registration realm from the proxy host, so `TELNYX_ATTACH_DOMAIN` must equal `TELNYX_ATTACH_PROXY`'s host). The tenant dialplan bridges to the registered extension and **falls back automatically to the assistant's public SIP subdomain** (`assistant-<id>.sip.telnyx.com`, reachable without registration) if the registration is down. With the `TELNYX_ATTACH_*` env vars unset, agents use the subdomain bridge only.

Both paths were verified end-to-end on lon1 on 2026-06-07 (registration completed 401→200 OK; test call answered by the assistant, greeting confirmed via STT).

## Changes

- Migration: `provider`, `model`, `telnyx_assistant_id`, `telnyx_uac_connection_id`, `telnyx_attach_extension{,_uuid}` columns on `v_ai_agents` (default provider `elevenlabs`, so existing rows are untouched)
- New dialplan template `telnyx-ai-agent-dial-plan-template.blade.php`
- UI: provider selector on create (only providers with a configured API key are offered), provider-specific voice/model selects, provider badge in the agents list, KB section hidden for Telnyx agents
- Config: `services.telnyx` block; `.env.example` documents `TELNYX_API_KEY` / `TELNYX_ATTACH_DOMAIN` / `TELNYX_ATTACH_PROXY`

## Deployment notes

Requires `TELNYX_API_KEY` on the servers (plus the `TELNYX_ATTACH_*` pair to enable SIP attach: `TELNYX_ATTACH_DOMAIN=172.236.17.39`, `TELNYX_ATTACH_PROXY=172.236.17.39:5060`). The providers ACL already whitelists Telnyx's signalling IP 192.76.120.14 on lon1. `php artisan migrate` + `npm run build` run as part of the standard Ansible deploy.

## Testing

- `php -l` clean on all changed PHP files (PHP 8.4)
- `npm run build` clean
- Telnyx API surface (assistants, UAC connections, voices, models) exercised live during the 2026-06-05/07 spike

🤖 Generated with [Claude Code](https://claude.com/claude-code)