### PR TITLE
Filter Telnyx model list to assistant-capable models

### DIFF
--- a/app/Services/TelnyxConvaiService.php
+++ b/app/Services/TelnyxConvaiService.php
@@ -189,7 +189,9 @@ class TelnyxConvaiService
         }
 
         return collect($response->json('data', []))
-            ->filter(fn ($m) => !empty($m['id']))
+            // /v2/ai/models also lists models the assistants API rejects
+            // ("Model X is not available for AI Assistants")
+            ->filter(fn ($m) => !empty($m['id']) && ($m['recommended_for_assistants'] ?? false))
             ->map(fn ($m) => ['value' => $m['id'], 'label' => $m['id']])
             ->values()
             ->toArray();


### PR DESCRIPTION
Follow-up to #29, found during deploy smoke test: `/v2/ai/models` lists all inference models but the assistants API rejects most ("Model openai/gpt-4o-mini is not available for AI Assistants"). Filter the UI model options on `recommended_for_assistants` (currently 10 models incl. gpt-5.x, claude-haiku-4-5, gemini-2.5-flash, Kimi-K2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)