### PR TITLE
Fix Blade @{{ escape in Telnyx dialplan template

### DIFF
--- a/resources/views/layouts/xml/telnyx-ai-agent-dial-plan-template.blade.php
+++ b/resources/views/layouts/xml/telnyx-ai-agent-dial-plan-template.blade.php
@@ -11,9 +11,11 @@
         <action application="set" data="ai_agent_uuid={{ $agent->ai_agent_uuid }}" />
 @if (!empty($agent->telnyx_attach_extension) && !empty($attach_domain))
         {{-- SIP attach: Telnyx registers this extension into the attach domain.
-             Falls through to the public assistant subdomain if unregistered. --}}
-        <action application="bridge" data="user/{{ $agent->telnyx_attach_extension }}@{{ $attach_domain }}" />
+             Falls through to the public assistant subdomain if unregistered.
+             NB: "@" must stay inside the echo — a literal "@{{" is Blade's
+             escape syntax and renders the braces verbatim. --}}
+        <action application="bridge" data="user/{{ $agent->telnyx_attach_extension . '@' . $attach_domain }}" />
 @endif
-        <action application="bridge" data="sofia/external/sip:agent@{{ $agent->telnyx_assistant_id }}.sip.telnyx.com" />
+        <action application="bridge" data="sofia/external/sip:{{ 'agent@' . $agent->telnyx_assistant_id }}.sip.telnyx.com" />
     </condition>
 </extension>


### PR DESCRIPTION
Both bridge lines in the Telnyx dialplan template rendered literal `{{ ... }}` because `@{{` is Blade's escape syntax. Move the `@` inside the echo. Found provisioning the first real Telnyx agent (9251).

🤖 Generated with [Claude Code](https://claude.com/claude-code)