### PR TITLE
Set continue_on_fail in Telnyx dialplan failover

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"2837b1fa-ec85-499a-95ed-09f32c436112","pid":2734723,"procStart":"227155355","acquiredAt":1780851710818}

--- a/resources/views/layouts/xml/telnyx-ai-agent-dial-plan-template.blade.php
+++ b/resources/views/layouts/xml/telnyx-ai-agent-dial-plan-template.blade.php
@@ -4,6 +4,9 @@
         <action application="answer" data="" />
         <action application="sleep" data="1000" />
         <action application="set" data="hangup_after_bridge=true" />
+        {{-- a failed bridge hangs the channel up by default; needed so the
+             SIP-attach bridge can fall through to the subdomain bridge --}}
+        <action application="set" data="continue_on_fail=true" />
         <action application="set" data="absolute_codec_string=PCMU,PCMA" />
         <action application="set" data="ringback=$${uk-ring}" />
         <action application="set" data="transfer_ringback=$${uk-ring}" />


### PR DESCRIPTION
Found testing 9251: a failed bridge hangs the channel up by default, so when the SIP-attach registration was down the call died with USER_NOT_REGISTERED instead of falling through to the assistant-subdomain bridge. `continue_on_fail=true` enables the documented failover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)