### PR TITLE
Reception agent: provider-driven summon (Telnyx support)

### DIFF
--- a/app/Services/Convai/ConvaiProviderInterface.php
+++ b/app/Services/Convai/ConvaiProviderInterface.php
@@ -47,4 +47,11 @@ interface ConvaiProviderInterface
      * Extra data the dialplan view needs beyond ['agent' => ...].
      */
     public function dialplanData(AiAgent $agent): array;
+
+    /**
+     * FreeSWITCH dial string for ESL-originating the agent leg straight into a
+     * conference (used by the reception-agent summon). May be a `|` failover
+     * list. Throw if the agent isn't provisioned for this provider.
+     */
+    public function summonEndpoint(AiAgent $agent): string;
 }

--- a/app/Services/Convai/ElevenLabsConvaiProvider.php
+++ b/app/Services/Convai/ElevenLabsConvaiProvider.php
@@ -97,4 +97,16 @@ class ElevenLabsConvaiProvider implements ConvaiProviderInterface
     {
         return [];
     }
+
+    public function summonEndpoint(AiAgent $agent): string
+    {
+        if (!$agent->elevenlabs_agent_id || !$agent->agent_extension) {
+            throw new \RuntimeException('ElevenLabs agent not provisioned (missing agent id / extension).');
+        }
+
+        return sprintf(
+            'sofia/external/sip:%s@sip.rtc.elevenlabs.io:5060;transport=tcp',
+            $agent->agent_extension
+        );
+    }
 }

--- a/app/Services/Convai/TelnyxConvaiProvider.php
+++ b/app/Services/Convai/TelnyxConvaiProvider.php
@@ -116,6 +116,25 @@ class TelnyxConvaiProvider implements ConvaiProviderInterface
         ];
     }
 
+    public function summonEndpoint(AiAgent $agent): string
+    {
+        if (!$agent->telnyx_assistant_id) {
+            throw new \RuntimeException('Telnyx agent not provisioned (missing assistant id).');
+        }
+
+        // Public assistant subdomain — always reachable, no registration needed.
+        $subdomain = sprintf('sofia/external/sip:agent@%s.sip.telnyx.com', $agent->telnyx_assistant_id);
+
+        // Prefer the registered SIP-attach extension (mirrors the dialplan
+        // template) and fail over to the subdomain if it's not registered.
+        $attachDomain = (string) config('services.telnyx.attach_domain', '');
+        if ($agent->telnyx_attach_extension && $attachDomain !== '') {
+            return sprintf('user/%s@%s|%s', $agent->telnyx_attach_extension, $attachDomain, $subdomain);
+        }
+
+        return $subdomain;
+    }
+
     /**
      * Create the attach extension + UAC connection so Telnyx registers in.
      *

--- a/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
@@ -4,6 +4,7 @@ namespace App\Services\ReceptionAgent;
 
 use App\Models\AiAgent;
 use App\Models\Domain;
+use App\Services\Convai\ConvaiProviderRegistry;
 use App\Services\FreeswitchEslService;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Str;
@@ -46,7 +47,7 @@ class ReceptionAgentSummonService
             ->where('agent_enabled', 'true')
             ->first();
 
-        if (!$agent || !$agent->elevenlabs_agent_id || !$agent->agent_extension) {
+        if (!$agent || !$agent->agent_extension) {
             throw new RuntimeException('No active reception agent provisioned for domain ' . $domainUuid);
         }
 
@@ -56,10 +57,11 @@ class ReceptionAgentSummonService
         $conversationId = (string) Str::uuid();
         $agentLegUuid   = (string) Str::uuid();
 
-        $endpoint = sprintf(
-            'sofia/external/sip:%s@sip.rtc.elevenlabs.io:5060;transport=tcp',
-            $agent->agent_extension
-        );
+        // Provider-driven agent leg (ElevenLabs SIP trunk, or Telnyx SIP attach
+        // / assistant subdomain). summonEndpoint() throws if the agent isn't
+        // provisioned for its provider.
+        $provider = app(ConvaiProviderRegistry::class)->resolve($agent->provider);
+        $endpoint = $provider->summonEndpoint($agent);
 
         $vars = [
             'origination_uuid'              => $agentLegUuid,


### PR DESCRIPTION
## What
Makes the reception-agent **summon** provider-driven so the agent leg can be Telnyx, not just ElevenLabs. First step of migrating reception agents to Telnyx (ElevenLabs can't drive call transfers).

- New `summonEndpoint(AiAgent): string` on `ConvaiProviderInterface`.
- ElevenLabs: existing `sip.rtc.elevenlabs.io` trunk endpoint (unchanged).
- Telnyx: `user/<attach_ext>@<attach_domain>` with failover to `sofia/external/sip:agent@<assistant_id>.sip.telnyx.com` (mirrors `telnyx-ai-agent-dial-plan-template`).
- `ReceptionAgentSummonService` resolves `AiAgent.provider` via `ConvaiProviderRegistry` and uses `summonEndpoint()`; the summon guard is now provider-agnostic.

No behaviour change for existing ElevenLabs agents (same endpoint string).

## Next (separate PRs, per the wakeword plan)
Provision a Telnyx reception agent, deploy the missing `*9` trigger, validate Telnyx transfer, then the wakeword detection path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)