### PR TITLE
Fix reception-agent:provision option parsing + domain lookup

### DIFF
--- a/app/Console/Commands/ProvisionReceptionAgent.php
+++ b/app/Console/Commands/ProvisionReceptionAgent.php
@@ -27,7 +27,7 @@ class ProvisionReceptionAgent extends Command
         {--voice= : provider voice id}
         {--model=}
         {--language=en}
-        {--feature-code=*9}
+        {--feature-code= : feature code, default *9 (kept out of the signature default because Laravel treats =* as an array option)}
         {--enabled=true}';
 
     protected $description = 'Provision-or-update the per-domain reception agent (headless: no session/permission gate).';
@@ -35,9 +35,9 @@ class ProvisionReceptionAgent extends Command
     public function handle(ReceptionAgentController $controller): int
     {
         $domainArg = (string) $this->argument('domain');
-        $domain = Domain::where('domain_uuid', $domainArg)
-            ->orWhere('domain_name', $domainArg)
-            ->first();
+        $domain = \Illuminate\Support\Str::isUuid($domainArg)
+            ? Domain::where('domain_uuid', $domainArg)->first()
+            : Domain::where('domain_name', $domainArg)->first();
 
         if (!$domain) {
             $this->error("Domain not found: {$domainArg}");
@@ -49,7 +49,7 @@ class ProvisionReceptionAgent extends Command
 
         $inputs = [
             'agent_name'    => (string) $this->option('name'),
-            'feature_code'  => (string) $this->option('feature-code'),
+            'feature_code'  => (string) ($this->option('feature-code') ?: '*9'),
             'provider'      => $provider,
             'system_prompt' => $this->option('prompt') ?: null,
             'first_message' => $this->option('first-message') ?: null,

--- a/app/Console/Commands/ProvisionReceptionAgent.php
+++ b/app/Console/Commands/ProvisionReceptionAgent.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Http\Controllers\ReceptionAgentController;
+use App\Models\Domain;
+use Illuminate\Console\Command;
+
+/**
+ * Headless provision-or-update of the per-domain reception agent.
+ *
+ * Example (clone the 9251 Telnyx assistant config as a reception agent):
+ *   php artisan reception-agent:provision iqmobile.uk --provider=telnyx \
+ *     --name="IQ In-Call Assistant" \
+ *     --voice="Telnyx.Ultra.62ae83ad-4f6a-430b-af41-a9bede9286ca" \
+ *     --model="moonshotai/Kimi-K2.5" \
+ *     --prompt="You are an executive assistant who has been pulled into a live conference call..."
+ */
+class ProvisionReceptionAgent extends Command
+{
+    protected $signature = 'reception-agent:provision
+        {domain : domain_name (e.g. iqmobile.uk) or domain_uuid}
+        {--provider=telnyx}
+        {--name=Reception Agent}
+        {--prompt= : system prompt (defaults to the controller default)}
+        {--first-message=}
+        {--voice= : provider voice id}
+        {--model=}
+        {--language=en}
+        {--feature-code=*9}
+        {--enabled=true}';
+
+    protected $description = 'Provision-or-update the per-domain reception agent (headless: no session/permission gate).';
+
+    public function handle(ReceptionAgentController $controller): int
+    {
+        $domainArg = (string) $this->argument('domain');
+        $domain = Domain::where('domain_uuid', $domainArg)
+            ->orWhere('domain_name', $domainArg)
+            ->first();
+
+        if (!$domain) {
+            $this->error("Domain not found: {$domainArg}");
+
+            return self::FAILURE;
+        }
+
+        $provider = (string) $this->option('provider');
+
+        $inputs = [
+            'agent_name'    => (string) $this->option('name'),
+            'feature_code'  => (string) $this->option('feature-code'),
+            'provider'      => $provider,
+            'system_prompt' => $this->option('prompt') ?: null,
+            'first_message' => $this->option('first-message') ?: null,
+            'language'      => (string) $this->option('language'),
+            'agent_enabled' => (string) $this->option('enabled'),
+            'tools_enabled' => [],
+        ];
+        if ($model = $this->option('model')) {
+            $inputs['model'] = $model;
+        }
+        if ($voice = $this->option('voice')) {
+            $inputs['voice_id'] = $voice;
+            if ($provider === 'telnyx') {
+                $inputs['telnyx_voice_id'] = $voice;
+            }
+        }
+
+        try {
+            $agent = $controller->upsertReceptionAgent($domain->domain_uuid, $inputs);
+        } catch (\Throwable $e) {
+            $this->error('Provision failed: ' . $e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info(sprintf(
+            'Reception agent ready: domain=%s ext=%s provider=%s assistant=%s feature=%s enabled=%s',
+            $domain->domain_name,
+            $agent->agent_extension,
+            $agent->provider,
+            $agent->telnyx_assistant_id ?: ($agent->elevenlabs_agent_id ?: '-'),
+            $agent->feature_code,
+            $agent->agent_enabled,
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/ReceptionAgentController.php
+++ b/app/Http/Controllers/ReceptionAgentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\AiAgent;
 use App\Models\Dialplans;
 use App\Models\FusionCache;
+use App\Services\Convai\ConvaiProviderRegistry;
 use App\Services\ElevenLabsConvaiService;
 use App\Services\Tts\ElevenLabsTtsService;
 use Illuminate\Http\JsonResponse;
@@ -92,55 +93,66 @@ PROMPT;
         }
 
         $inputs = $request->validate([
-            'agent_name'     => 'required|string|max:100',
-            'feature_code'   => 'required|string|max:8',
-            'system_prompt'  => 'nullable|string',
-            'first_message'  => 'nullable|string|max:500',
-            'voice_id'       => 'nullable|string|max:255',
-            'language'       => 'nullable|string|max:20',
-            'agent_enabled'  => 'required|in:true,false',
-            'tools_enabled'  => 'array',
+            'agent_name'      => 'required|string|max:100',
+            'feature_code'    => 'required|string|max:8',
+            'provider'        => 'nullable|string|in:elevenlabs,telnyx',
+            'system_prompt'   => 'nullable|string',
+            'first_message'   => 'nullable|string|max:500',
+            'voice_id'        => 'nullable|string|max:255',
+            'telnyx_voice_id' => 'nullable|string|max:255',
+            'model'           => 'nullable|string|max:255',
+            'language'        => 'nullable|string|max:20',
+            'agent_enabled'   => 'required|in:true,false',
+            'tools_enabled'   => 'array',
         ]);
 
         try {
             DB::beginTransaction();
 
-            $convai = app(ElevenLabsConvaiService::class);
             $domainUuid = session('domain_uuid');
-
             $agent = AiAgent::reception()->forDomain($domainUuid)->first();
 
-            if (!$agent) {
-                // Provision: create the ConvAI agent on ElevenLabs first.
-                $created = $convai->createAgent(
-                    $inputs['agent_name'],
-                    $inputs['system_prompt'] ?? self::DEFAULT_SYSTEM_PROMPT,
-                    $inputs['first_message'] ?? self::DEFAULT_FIRST_MESSAGE,
-                    $inputs['voice_id'] ?? null,
-                    $inputs['language'] ?? 'en',
-                );
+            // Existing agent keeps its provider; a new one uses the requested
+            // provider (default elevenlabs).
+            $providerName = $agent->provider ?? ($inputs['provider'] ?? ConvaiProviderRegistry::DEFAULT);
+            $provider = app(ConvaiProviderRegistry::class)->resolve($providerName);
 
+            // Telnyx exposes its voice catalogue under a separate field.
+            if ($providerName === AiAgent::PROVIDER_TELNYX && !empty($inputs['telnyx_voice_id'])) {
+                $inputs['voice_id'] = $inputs['telnyx_voice_id'];
+            }
+
+            if (!$agent) {
                 $agentExtension = $this->allocateAgentExtension($domainUuid);
 
+                // Provision on the provider platform (no inbound phone number;
+                // the reception agent is reached via the summon).
+                $providerAttributes = $provider->provisionReceptionAgent(array_merge($inputs, [
+                    'agent_extension' => $agentExtension,
+                    'system_prompt'   => $inputs['system_prompt'] ?? self::DEFAULT_SYSTEM_PROMPT,
+                    'first_message'   => $inputs['first_message'] ?? self::DEFAULT_FIRST_MESSAGE,
+                ]));
+
                 $agent = new AiAgent();
-                $agent->fill([
-                    'domain_uuid'         => $domainUuid,
-                    'dialplan_uuid'       => Str::uuid(),
-                    'agent_name'          => $inputs['agent_name'],
-                    'agent_extension'     => $agentExtension,
-                    'elevenlabs_agent_id' => $created['agent_id'] ?? null,
-                    'system_prompt'       => $inputs['system_prompt'] ?? self::DEFAULT_SYSTEM_PROMPT,
-                    'first_message'      => $inputs['first_message'] ?? self::DEFAULT_FIRST_MESSAGE,
-                    'voice_id'            => $inputs['voice_id'] ?? null,
-                    'language'            => $inputs['language'] ?? 'en',
-                    'agent_enabled'       => $inputs['agent_enabled'],
-                    'mode'                => AiAgent::MODE_RECEPTION,
-                    'tools_enabled'       => $inputs['tools_enabled'] ?? [],
-                    'feature_code'        => $inputs['feature_code'],
-                    'description'         => 'Reception agent (*' . trim($inputs['feature_code'], '*') . ')',
-                    'insert_date'         => date('Y-m-d H:i:s'),
-                    'insert_user'         => session('user_uuid'),
-                ]);
+                $agent->fill(array_merge([
+                    'domain_uuid'     => $domainUuid,
+                    'dialplan_uuid'   => Str::uuid(),
+                    'agent_name'      => $inputs['agent_name'],
+                    'agent_extension' => $agentExtension,
+                    'provider'        => $providerName,
+                    'model'           => $inputs['model'] ?? null,
+                    'system_prompt'   => $inputs['system_prompt'] ?? self::DEFAULT_SYSTEM_PROMPT,
+                    'first_message'   => $inputs['first_message'] ?? self::DEFAULT_FIRST_MESSAGE,
+                    'voice_id'        => $inputs['voice_id'] ?? null,
+                    'language'        => $inputs['language'] ?? 'en',
+                    'agent_enabled'   => $inputs['agent_enabled'],
+                    'mode'            => AiAgent::MODE_RECEPTION,
+                    'tools_enabled'   => $inputs['tools_enabled'] ?? [],
+                    'feature_code'    => $inputs['feature_code'],
+                    'description'     => 'Reception agent (*' . trim($inputs['feature_code'], '*') . ')',
+                    'insert_date'     => date('Y-m-d H:i:s'),
+                    'insert_user'     => session('user_uuid'),
+                ], $providerAttributes));
                 $agent->save();
             } else {
                 $agent->fill([
@@ -157,22 +169,18 @@ PROMPT;
                 ]);
                 $agent->save();
 
-                if ($agent->elevenlabs_agent_id) {
-                    $convai->updateAgent(
-                        $agent->elevenlabs_agent_id,
-                        $agent->agent_name,
-                        $agent->system_prompt,
-                        $agent->first_message,
-                        $agent->voice_id,
-                        $agent->language ?? 'en',
-                    );
-                }
+                $provider->updateAgent($agent, [
+                    'agent_name'    => $agent->agent_name,
+                    'system_prompt' => $agent->system_prompt,
+                    'first_message' => $agent->first_message,
+                    'voice_id'      => $agent->voice_id,
+                    'model'         => $agent->model,
+                    'language'      => $agent->language ?? 'en',
+                ]);
             }
 
             // Always sync the tool surface; tool toggles can change between saves.
-            if ($agent->elevenlabs_agent_id) {
-                $convai->syncReceptionAgentTools($agent);
-            }
+            $provider->syncReceptionAgentTools($agent);
 
             $this->generateFeatureCodeDialPlan($agent);
             $this->generateBindMetaAppDialPlan($agent);

--- a/app/Http/Controllers/ReceptionAgentController.php
+++ b/app/Http/Controllers/ReceptionAgentController.php
@@ -107,9 +107,26 @@ PROMPT;
         ]);
 
         try {
+            $agent = $this->upsertReceptionAgent(session('domain_uuid'), $inputs, session('user_uuid'));
+
+            return response()->json(['agent' => $agent->fresh()]);
+        } catch (Throwable $e) {
+            logger()->error('reception agent update failed: ' . $e->getMessage());
+
+            return response()->json(['error' => $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * Provision-or-update the per-domain reception agent. Headless (no session
+     * or permission gate) so it can be driven by update() OR the
+     * `reception-agent:provision` console command.
+     */
+    public function upsertReceptionAgent(string $domainUuid, array $inputs, ?string $userUuid = null): AiAgent
+    {
+        try {
             DB::beginTransaction();
 
-            $domainUuid = session('domain_uuid');
             $agent = AiAgent::reception()->forDomain($domainUuid)->first();
 
             // Existing agent keeps its provider; a new one uses the requested
@@ -151,7 +168,7 @@ PROMPT;
                     'feature_code'    => $inputs['feature_code'],
                     'description'     => 'Reception agent (*' . trim($inputs['feature_code'], '*') . ')',
                     'insert_date'     => date('Y-m-d H:i:s'),
-                    'insert_user'     => session('user_uuid'),
+                    'insert_user'     => $userUuid,
                 ], $providerAttributes));
                 $agent->save();
             } else {
@@ -165,7 +182,7 @@ PROMPT;
                     'tools_enabled' => $inputs['tools_enabled'] ?? $agent->tools_enabled,
                     'feature_code'  => $inputs['feature_code'],
                     'update_date'   => date('Y-m-d H:i:s'),
-                    'update_user'   => session('user_uuid'),
+                    'update_user'   => $userUuid,
                 ]);
                 $agent->save();
 
@@ -187,11 +204,10 @@ PROMPT;
 
             DB::commit();
 
-            return response()->json(['agent' => $agent->fresh()]);
+            return $agent;
         } catch (Throwable $e) {
             DB::rollBack();
-            logger()->error('reception agent update failed: ' . $e->getMessage());
-            return response()->json(['error' => $e->getMessage()], 500);
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
+++ b/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
@@ -59,6 +59,8 @@ class ReceptionAgentToolController extends Controller
                 'park_call'          => $this->tools->parkCall($session),
                 'bring_back'         => $this->tools->bringBack($session, (string) ($args['slot'] ?? '')),
                 'three_way_add'      => $this->tools->threeWayAdd($session, (string) ($args['extension'] ?? '')),
+                'take_notes'         => $this->tools->takeNotes($session, (string) ($args['note'] ?? '')),
+                'email_reminder'     => $this->tools->emailReminder($session, (string) ($args['to'] ?? ''), (string) ($args['subject'] ?? ''), (string) ($args['body'] ?? '')),
                 'complete_and_exit'  => $this->tools->completeAndExit($session, $args['message'] ?? null),
                 'get_time_in_city'   => $this->tools->getTimeInCity((string) ($args['city'] ?? '')),
                 'get_weather'        => $this->tools->getWeather((string) ($args['city'] ?? '')),

--- a/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
+++ b/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
@@ -25,6 +25,26 @@ class ReceptionAgentToolController extends Controller
     {
     }
 
+    /**
+     * Telnyx assistant.initialization (dynamic_variables_webhook_url). Resolves
+     * the caller-id correlation token (telnyx_end_user_target) to our
+     * conversation_id and returns it as a dynamic variable, which the assistant
+     * then injects into every tool call via a templated header.
+     */
+    public function dynamicVariables(Request $request): JsonResponse
+    {
+        $target = (string) ($request->input('data.payload.telnyx_end_user_target')
+            ?? data_get($request->all(), 'data.payload.telnyx_end_user_target', ''));
+
+        $conversationId = $target !== ''
+            ? ReceptionAgentSummonService::conversationIdForTelnyxToken($target)
+            : null;
+
+        return response()->json([
+            'dynamic_variables' => array_filter(['conversation_id' => $conversationId]),
+        ]);
+    }
+
     public function handle(Request $request): JsonResponse
     {
         $tool = (string) $request->input('tool_name', $request->input('tool', ''));
@@ -32,7 +52,12 @@ class ReceptionAgentToolController extends Controller
             return response()->json(['ok' => false, 'error' => 'tool_name required'], 422);
         }
 
-        $convId = (string) $request->input('conversation_id', $request->input('dynamic_variables.conversation_id', ''));
+        // Telnyx carries conversation_id in a templated tool header; ElevenLabs
+        // puts it in the body (directly or under dynamic_variables).
+        $convId = (string) $request->header('X-Voxra-Conversation-Id', '');
+        if ($convId === '') {
+            $convId = (string) $request->input('conversation_id', $request->input('dynamic_variables.conversation_id', ''));
+        }
         if ($convId === '') {
             // ElevenLabs nests dynamic variables under a different shape depending on version.
             $convId = (string) data_get($request->all(), 'dynamic_variables.conversation_id', '');

--- a/app/Services/Convai/ConvaiProviderInterface.php
+++ b/app/Services/Convai/ConvaiProviderInterface.php
@@ -54,4 +54,19 @@ interface ConvaiProviderInterface
      * list. Throw if the agent isn't provisioned for this provider.
      */
     public function summonEndpoint(AiAgent $agent): string;
+
+    /**
+     * Provision a reception-mode agent on the provider platform (the call-path
+     * resources a reception agent needs — e.g. an ElevenLabs agent, or a Telnyx
+     * assistant + SIP attach — but NOT a direct inbound phone number).
+     *
+     * @param  array  $inputs  agent_name, system_prompt, first_message, voice_id, language, model, agent_extension
+     * @return array  attributes to persist on the AiAgent row
+     */
+    public function provisionReceptionAgent(array $inputs): array;
+
+    /**
+     * Register/refresh the reception-agent tool surface on the provider platform.
+     */
+    public function syncReceptionAgentTools(AiAgent $agent): void;
 }

--- a/app/Services/Convai/ElevenLabsConvaiProvider.php
+++ b/app/Services/Convai/ElevenLabsConvaiProvider.php
@@ -109,4 +109,24 @@ class ElevenLabsConvaiProvider implements ConvaiProviderInterface
             $agent->agent_extension
         );
     }
+
+    public function provisionReceptionAgent(array $inputs): array
+    {
+        // Reception agents reach ElevenLabs via the summon SIP trunk, so unlike
+        // a direct agent we do NOT allocate a phone number here.
+        $created = $this->service->createAgent(
+            $inputs['agent_name'],
+            $inputs['system_prompt'] ?? null,
+            $inputs['first_message'] ?? null,
+            $inputs['voice_id'] ?? null,
+            $inputs['language'] ?? 'en',
+        );
+
+        return ['elevenlabs_agent_id' => $created['agent_id'] ?? null];
+    }
+
+    public function syncReceptionAgentTools(AiAgent $agent): void
+    {
+        $this->service->syncReceptionAgentTools($agent);
+    }
 }

--- a/app/Services/Convai/TelnyxConvaiProvider.php
+++ b/app/Services/Convai/TelnyxConvaiProvider.php
@@ -135,6 +135,18 @@ class TelnyxConvaiProvider implements ConvaiProviderInterface
         return $subdomain;
     }
 
+    public function provisionReceptionAgent(array $inputs): array
+    {
+        // A reception agent uses the same call path as a direct Telnyx agent:
+        // create the assistant + SIP attach (no inbound phone number).
+        return $this->provisionAgent($inputs);
+    }
+
+    public function syncReceptionAgentTools(AiAgent $agent): void
+    {
+        $this->service->syncReceptionAgentTools($agent);
+    }
+
     /**
      * Create the attach extension + UAC connection so Telnyx registers in.
      *

--- a/app/Services/ElevenLabsConvaiService.php
+++ b/app/Services/ElevenLabsConvaiService.php
@@ -380,60 +380,8 @@ class ElevenLabsConvaiService
             ];
         };
 
-        if ($enabled['lookup_user'] ?? true) {
-            $defs[] = $make('lookup_user', 'Find a colleague by name in the directory; returns extension and full name.', [
-                'query' => ['type' => 'string', 'description' => 'Person name or extension to search for'],
-            ], ['query']);
-        }
-        if ($enabled['transfer_call'] ?? true) {
-            $defs[] = $make('transfer_call', 'Blind-transfer the held call to an extension and exit.', [
-                'extension' => ['type' => 'string', 'description' => 'Target extension number'],
-            ], ['extension']);
-        }
-        if ($enabled['announced_transfer'] ?? true) {
-            $defs[] = $make('announced_transfer', 'Announced transfer: ring the target, intro the call to them, then drop yourself when the summoner hangs up so the original caller is connected.', [
-                'extension' => ['type' => 'string', 'description' => 'Target extension number'],
-            ], ['extension']);
-        }
-        if ($enabled['park_call'] ?? true) {
-            $defs[] = $make('park_call', 'Park the held call to a parking slot and read back the slot number.', []);
-        }
-        if ($enabled['bring_back'] ?? true) {
-            $defs[] = $make('bring_back', 'Retrieve a previously parked call by slot number.', [
-                'slot' => ['type' => 'string', 'description' => 'Park slot number to retrieve'],
-            ], ['slot']);
-        }
-        if ($enabled['three_way_add'] ?? true) {
-            $defs[] = $make('three_way_add', 'Add another extension to the current call as a three-way participant.', [
-                'extension' => ['type' => 'string', 'description' => 'Extension to add to the call'],
-            ], ['extension']);
-        }
-        if ($enabled['take_notes'] ?? true) {
-            $defs[] = $make('take_notes', 'Record a note from the call; notes are kept and included in the post-call summary.', [
-                'note' => ['type' => 'string', 'description' => 'The note text to record'],
-            ], ['note']);
-        }
-        if ($enabled['email_reminder'] ?? true) {
-            $defs[] = $make('email_reminder', 'Email a reminder or summary to an address the caller gives you. Ask for the email address if you do not have it.', [
-                'to' => ['type' => 'string', 'description' => 'Recipient email address'],
-                'subject' => ['type' => 'string', 'description' => 'Email subject line'],
-                'body' => ['type' => 'string', 'description' => 'Email body text'],
-            ], ['to', 'body']);
-        }
-        if ($enabled['complete_and_exit'] ?? true) {
-            $defs[] = $make('complete_and_exit', 'Call this once you have completed the user\'s request to leave the call cleanly.', [
-                'message' => ['type' => 'string', 'description' => 'Optional final spoken message before exiting'],
-            ]);
-        }
-        if ($enabled['get_time_in_city'] ?? true) {
-            $defs[] = $make('get_time_in_city', 'Get the current local time in a named city.', [
-                'city' => ['type' => 'string', 'description' => 'City name (e.g. New York, Tokyo)'],
-            ], ['city']);
-        }
-        if ($enabled['get_weather'] ?? true) {
-            $defs[] = $make('get_weather', 'Get the current weather in a named city.', [
-                'city' => ['type' => 'string', 'description' => 'City name'],
-            ], ['city']);
+        foreach (\App\Services\ReceptionAgent\ReceptionAgentToolDefinitions::list($enabled) as $t) {
+            $defs[] = $make($t['name'], $t['description'], $t['properties'], $t['required']);
         }
 
         return $defs;

--- a/app/Services/ElevenLabsConvaiService.php
+++ b/app/Services/ElevenLabsConvaiService.php
@@ -408,6 +408,18 @@ class ElevenLabsConvaiService
                 'extension' => ['type' => 'string', 'description' => 'Extension to add to the call'],
             ], ['extension']);
         }
+        if ($enabled['take_notes'] ?? true) {
+            $defs[] = $make('take_notes', 'Record a note from the call; notes are kept and included in the post-call summary.', [
+                'note' => ['type' => 'string', 'description' => 'The note text to record'],
+            ], ['note']);
+        }
+        if ($enabled['email_reminder'] ?? true) {
+            $defs[] = $make('email_reminder', 'Email a reminder or summary to an address the caller gives you. Ask for the email address if you do not have it.', [
+                'to' => ['type' => 'string', 'description' => 'Recipient email address'],
+                'subject' => ['type' => 'string', 'description' => 'Email subject line'],
+                'body' => ['type' => 'string', 'description' => 'Email body text'],
+            ], ['to', 'body']);
+        }
         if ($enabled['complete_and_exit'] ?? true) {
             $defs[] = $make('complete_and_exit', 'Call this once you have completed the user\'s request to leave the call cleanly.', [
                 'message' => ['type' => 'string', 'description' => 'Optional final spoken message before exiting'],

--- a/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
@@ -84,6 +84,17 @@ class ReceptionAgentSummonService
             'sip_h_X-Voxra-Conf-Name'       => $confName,
         ];
 
+        // Telnyx's assistant.initialization webhook only exposes
+        // telnyx_end_user_target (the caller id), not SIP headers — so encode a
+        // numeric correlation token as the agent leg's caller id and map it to
+        // this conversation. The dynamic-variables webhook resolves it back to
+        // conversation_id, which tool calls then carry in a templated header.
+        if ($agent->provider === AiAgent::PROVIDER_TELNYX) {
+            $token = (string) random_int(1000000000, 1999999999);
+            $vars['origination_caller_id_number'] = $token;
+            Redis::setex(self::SESSION_KEY_PREFIX . 'telnyxtoken:' . $token, self::SESSION_TTL_SECONDS, $conversationId);
+        }
+
         $this->esl->originate(
             $endpoint,
             sprintf('&conference(%s@default)', $confName),
@@ -146,5 +157,21 @@ class ReceptionAgentSummonService
         if ($session && !empty($session['conf_name'])) {
             Redis::del(self::SESSION_KEY_PREFIX . 'conf:' . $session['conf_name']);
         }
+    }
+
+    /**
+     * Resolve a Telnyx caller-id correlation token (telnyx_end_user_target) back
+     * to its conversation_id, for the dynamic-variables webhook. Digits-only to
+     * survive any +/formatting Telnyx applies to the caller id.
+     */
+    public static function conversationIdForTelnyxToken(string $token): ?string
+    {
+        $token = preg_replace('/\D+/', '', $token);
+        if ($token === '') {
+            return null;
+        }
+        $cid = Redis::get(self::SESSION_KEY_PREFIX . 'telnyxtoken:' . $token);
+
+        return $cid ?: null;
     }
 }

--- a/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Services\ReceptionAgent;
+
+/**
+ * Provider-neutral definitions of the reception-agent tools.
+ *
+ * Each provider (ElevenLabs, Telnyx) renders these into its own tool schema.
+ * The dispatch endpoint is a single webhook; the `tool_name` (enum) in the body
+ * selects the method, and `conversation_id` ties the call to its Redis session.
+ *
+ * `properties` are JSON-Schema property maps; `required` lists required arg
+ * names (tool_name + conversation_id are always added by the renderers).
+ */
+class ReceptionAgentToolDefinitions
+{
+    /**
+     * @param array<string,bool> $enabled per-tool on/off map (agent->tools_enabled)
+     * @return array<int, array{name:string, description:string, properties:array<string,mixed>, required:array<int,string>}>
+     */
+    public static function list(array $enabled): array
+    {
+        $all = [
+            [
+                'name' => 'lookup_user',
+                'description' => 'Find a colleague by name in the directory; returns extension and full name.',
+                'properties' => ['query' => ['type' => 'string', 'description' => 'Person name or extension to search for']],
+                'required' => ['query'],
+            ],
+            [
+                'name' => 'transfer_call',
+                'description' => 'Blind-transfer the held call to an extension and exit.',
+                'properties' => ['extension' => ['type' => 'string', 'description' => 'Target extension number']],
+                'required' => ['extension'],
+            ],
+            [
+                'name' => 'announced_transfer',
+                'description' => 'Announced (warm) transfer: ring the target, introduce the call, then drop yourself so the original caller is connected.',
+                'properties' => ['extension' => ['type' => 'string', 'description' => 'Target extension number']],
+                'required' => ['extension'],
+            ],
+            [
+                'name' => 'park_call',
+                'description' => 'Park the held call to a parking slot and read back the slot number.',
+                'properties' => [],
+                'required' => [],
+            ],
+            [
+                'name' => 'bring_back',
+                'description' => 'Retrieve a previously parked call by slot number.',
+                'properties' => ['slot' => ['type' => 'string', 'description' => 'Park slot number to retrieve']],
+                'required' => ['slot'],
+            ],
+            [
+                'name' => 'three_way_add',
+                'description' => 'Add another extension to the current call as a three-way participant.',
+                'properties' => ['extension' => ['type' => 'string', 'description' => 'Extension to add to the call']],
+                'required' => ['extension'],
+            ],
+            [
+                'name' => 'take_notes',
+                'description' => 'Record a note from the call; notes are kept and included in the post-call summary.',
+                'properties' => ['note' => ['type' => 'string', 'description' => 'The note text to record']],
+                'required' => ['note'],
+            ],
+            [
+                'name' => 'email_reminder',
+                'description' => 'Email a reminder or summary to an address the caller gives you. Ask for the email address if you do not have it.',
+                'properties' => [
+                    'to' => ['type' => 'string', 'description' => 'Recipient email address'],
+                    'subject' => ['type' => 'string', 'description' => 'Email subject line'],
+                    'body' => ['type' => 'string', 'description' => 'Email body text'],
+                ],
+                'required' => ['to', 'body'],
+            ],
+            [
+                'name' => 'complete_and_exit',
+                'description' => 'Call this once you have completed the user\'s request to leave the call cleanly.',
+                'properties' => ['message' => ['type' => 'string', 'description' => 'Optional final spoken message before exiting']],
+                'required' => [],
+            ],
+            [
+                'name' => 'get_time_in_city',
+                'description' => 'Get the current local time in a named city.',
+                'properties' => ['city' => ['type' => 'string', 'description' => 'City name (e.g. New York, Tokyo)']],
+                'required' => ['city'],
+            ],
+            [
+                'name' => 'get_weather',
+                'description' => 'Get the current weather in a named city.',
+                'properties' => ['city' => ['type' => 'string', 'description' => 'City name']],
+                'required' => ['city'],
+            ],
+        ];
+
+        return array_values(array_filter($all, fn ($t) => $enabled[$t['name']] ?? true));
+    }
+}

--- a/app/Services/ReceptionAgent/ReceptionAgentToolService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolService.php
@@ -8,6 +8,7 @@ use DateTime;
 use DateTimeZone;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Str;
 use RuntimeException;
@@ -192,6 +193,57 @@ class ReceptionAgentToolService
         }
 
         return ['ok' => true, 'message' => $message ?? 'Done'];
+    }
+
+    /**
+     * Capture a note during the call. Notes accrue on the Redis session so they
+     * can be surfaced/emailed in the post-call summary.
+     */
+    public function takeNotes(array $session, string $note): array
+    {
+        $note = trim($note);
+        if ($note === '') {
+            return ['ok' => false, 'message' => 'Nothing to note'];
+        }
+
+        $convId = (string) ($session['conversation_id'] ?? '');
+        if ($convId !== '') {
+            $current = ReceptionAgentSummonService::loadSession($convId) ?? $session;
+            $notes = $current['notes'] ?? [];
+            $notes[] = ['at' => now()->toIso8601String(), 'text' => $note];
+            $current['notes'] = $notes;
+            ReceptionAgentSummonService::saveSession($convId, $current);
+        }
+
+        return ['ok' => true, 'message' => 'Noted'];
+    }
+
+    /**
+     * Email a reminder/summary to an address the caller provides.
+     */
+    public function emailReminder(array $session, string $to, string $subject, string $body): array
+    {
+        $to = trim($to);
+        if (!filter_var($to, FILTER_VALIDATE_EMAIL)) {
+            return ['ok' => false, 'message' => 'I need a valid email address to send to'];
+        }
+
+        $subject = trim($subject) !== '' ? trim($subject) : 'Reminder from your call';
+        $body = trim($body);
+        if ($body === '') {
+            return ['ok' => false, 'message' => 'There is nothing to send yet'];
+        }
+
+        try {
+            Mail::raw($body, function ($message) use ($to, $subject) {
+                $message->to($to)->subject($subject);
+            });
+        } catch (Throwable $e) {
+            logger()->error('reception-agent email_reminder failed: ' . $e->getMessage());
+            return ['ok' => false, 'message' => 'Sorry, I could not send that email'];
+        }
+
+        return ['ok' => true, 'message' => "Emailed {$to}"];
     }
 
     public function getTimeInCity(string $city): array

--- a/app/Services/TelnyxConvaiService.php
+++ b/app/Services/TelnyxConvaiService.php
@@ -93,6 +93,72 @@ class TelnyxConvaiService
     }
 
     /**
+     * Register the reception-agent tool surface on a Telnyx assistant and wire
+     * the dynamic-variables webhook (so each tool call carries conversation_id).
+     *
+     * Telnyx webhook tool shape: {"type":"webhook","webhook":{name,description,
+     * url,method,headers,body_parameters}}. The assistant fills body_parameters;
+     * conversation_id is injected via a templated header ({{conversation_id}}),
+     * resolved from the dynamic-variables webhook at call start.
+     *
+     * POST /v2/ai/assistants/{assistant_id}
+     */
+    public function syncReceptionAgentTools(\App\Models\AiAgent $agent): array
+    {
+        if (!$agent->telnyx_assistant_id) {
+            throw new RuntimeException('Agent has no Telnyx assistant id; create the assistant first');
+        }
+
+        $base = rtrim((string) config('app.url', ''), '/');
+        if ($base === '') {
+            throw new RuntimeException('APP_URL must be set for Telnyx tool webhooks');
+        }
+        // Telnyx-specific routes (the ElevenLabs /tool route is gated by an
+        // ElevenLabs-signature middleware Telnyx calls can't satisfy).
+        $toolUrl = $base . '/webhooks/voxra/reception-agent/tool-telnyx';
+        $dynVarsUrl = $base . '/webhooks/voxra/reception-agent/dynamic-variables';
+
+        $tools = [];
+        foreach (\App\Services\ReceptionAgent\ReceptionAgentToolDefinitions::list((array) ($agent->tools_enabled ?? [])) as $t) {
+            $tools[] = [
+                'type' => 'webhook',
+                'webhook' => [
+                    'name' => $t['name'],
+                    'description' => $t['description'],
+                    'url' => $toolUrl,
+                    'method' => 'POST',
+                    'headers' => [
+                        ['name' => 'Content-Type', 'value' => 'application/json'],
+                        // conversation_id resolved from the dynamic-variables webhook.
+                        ['name' => 'X-Voxra-Conversation-Id', 'value' => '{{conversation_id}}'],
+                    ],
+                    'body_parameters' => [
+                        'type' => 'object',
+                        'properties' => array_merge([
+                            'tool_name' => ['type' => 'string', 'enum' => [$t['name']]],
+                        ], $t['properties']),
+                        'required' => array_values(array_unique(array_merge(['tool_name'], $t['required']))),
+                    ],
+                ],
+            ];
+        }
+
+        $body = [
+            'tools' => $tools,
+            'dynamic_variables_webhook_url' => $dynVarsUrl,
+        ];
+
+        $response = $this->http()->post("v2/ai/assistants/{$agent->telnyx_assistant_id}", $body);
+
+        if (!$response->successful()) {
+            logger('Telnyx sync reception tools error: ' . $response->body());
+            throw new RuntimeException('Failed to sync Telnyx reception tools: ' . $this->errorDetail($response));
+        }
+
+        return $response->json();
+    }
+
+    /**
      * Get an assistant's current configuration.
      * GET /v2/ai/assistants/{assistant_id}
      */

--- a/routes/web.php
+++ b/routes/web.php
@@ -100,6 +100,18 @@ Route::post('/webhooks/voxra/reception-agent/tool', [
     \App\Http\Controllers\Webhooks\ReceptionAgentToolController::class, 'handle',
 ])->middleware(\App\Http\Middleware\VerifyElevenLabsSignature::class);
 
+// Telnyx AI Assistant tool callbacks + dynamic-variables (assistant.initialization).
+// Both are effectively token-guarded: tool calls need a valid (unguessable,
+// short-lived) conversation_id session, and dynamic-variables only echoes a
+// conversation_id when given a valid caller-id correlation token.
+// TODO(hardening): add Telnyx Ed25519 signature verification before broad prod use.
+Route::post('/webhooks/voxra/reception-agent/tool-telnyx', [
+    \App\Http\Controllers\Webhooks\ReceptionAgentToolController::class, 'handle',
+]);
+Route::post('/webhooks/voxra/reception-agent/dynamic-variables', [
+    \App\Http\Controllers\Webhooks\ReceptionAgentToolController::class, 'dynamicVariables',
+]);
+
 // Routes for 2FA email challenge. Used as a backup when 2FA is not enabled.
 Route::get('/email-challenge', [App\Http\Controllers\Auth\EmailChallengeController::class, 'create'])->name('email-challenge.login');
 Route::put('/email-challenge', [App\Http\Controllers\Auth\EmailChallengeController::class, 'update'])


### PR DESCRIPTION
Two fixes to the new provision command: (1) `--feature-code` default removed from the signature (Laravel treats `=*` as an array option, breaking string casts) and defaulted in code; (2) domain argument branches on `Str::isUuid` so a domain_name isn't compared against the uuid column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)