### PR TITLE
Fix *9 bind: execute bind_meta_app application (not set var)

### DIFF
--- a/resources/views/layouts/xml/reception-agent-bind-meta-app-template.blade.php
+++ b/resources/views/layouts/xml/reception-agent-bind-meta-app-template.blade.php
@@ -5,6 +5,6 @@
              listen=ab (either leg's DTMF triggers), respond=s (action runs on the
              leg that pressed). Falls through (continue=true) so this never breaks
              normal call routing. --}}
-        <action application="set" data="bind_meta_app=9 ab s execute_extension::*9 XML ${domain_name}"/>
+        <action application="bind_meta_app" data="9 ab s execute_extension::*9 XML ${domain_name}"/>
     </condition>
 </extension>


### PR DESCRIPTION
The reception-agent bind template used `application="set" data="bind_meta_app=9 …"`, which only sets a channel variable — the `*9` binding was never armed (live log: `Digit NOT match binding [*9]`). Execute the `bind_meta_app` application instead. This is what made pressing `*9` mid-call do nothing. 🤖 Generated with [Claude Code](https://claude.com/claude-code)