### PR TITLE
Fix *9 conference transfer: eval not api app

### DIFF
--- a/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
+++ b/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
@@ -10,7 +10,7 @@
 
         <!-- Pull the peer leg into a fresh conference. ${bridge_uuid} is set by
              FreeSWITCH for the duration of (and persists past) the bridge. -->
-        <action application="api" data="uuid_transfer ${bridge_uuid} 'conference:${voxra_conf_name}@@default' inline"/>
+        <action application="eval" data="${uuid_transfer(${bridge_uuid} 'conference:${voxra_conf_name}@@default' inline)}"/>
 
         <!-- Spawn the ElevenLabs agent leg into the same conference. The Lua
              call is synchronous so the originate is in flight by the time we


### PR DESCRIPTION
The *9 dialplan invoked `uuid_transfer` via `<action application="api">`, which isn't a valid dialplan application (`Invalid Application api` → call dropped `DESTINATION_OUT_OF_ORDER`). Use `eval` with the `${uuid_transfer(...)}` expansion. This is the last blocker for *9 → conference. 🤖 Generated with [Claude Code](https://claude.com/claude-code)