### PR TITLE
Keep peer in *9 conference + silence MOH/announcements

### DIFF
--- a/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
+++ b/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
@@ -8,8 +8,21 @@
         <action application="set" data="voxra_originator_uuid=${uuid}"/>
         <action application="set" data="voxra_peer_uuid=${bridge_uuid}"/>
 
+        <!-- Silence MOH + the "you are the only person" announcement + enter/exit
+             beeps for this leg, so the brief moment before the conference fills is
+             silent rather than music. Both parties stay in and can keep talking. -->
+        <action application="set" data="conference_moh_sound=silence_stream://-1"/>
+        <action application="set" data="conference_enter_sound=silence_stream://1"/>
+        <action application="set" data="conference_exit_sound=silence_stream://1"/>
+
         <!-- Pull the peer leg into a fresh conference. ${bridge_uuid} is set by
-             FreeSWITCH for the duration of (and persists past) the bridge. -->
+             FreeSWITCH for the duration of (and persists past) the bridge. Keep the
+             peer alive across the bridge break (else hangup_after_bridge drops it
+             before it lands in the conference) and silence its MOH too. -->
+        <action application="eval" data="${uuid_setvar(${bridge_uuid} hangup_after_bridge false)}"/>
+        <action application="eval" data="${uuid_setvar(${bridge_uuid} conference_moh_sound silence_stream://-1)}"/>
+        <action application="eval" data="${uuid_setvar(${bridge_uuid} conference_enter_sound silence_stream://1)}"/>
+        <action application="eval" data="${uuid_setvar(${bridge_uuid} conference_exit_sound silence_stream://1)}"/>
         <action application="eval" data="${uuid_transfer(${bridge_uuid} 'conference:${voxra_conf_name}@@default' inline)}"/>
 
         <!-- Spawn the ElevenLabs agent leg into the same conference. The Lua


### PR DESCRIPTION
From live testing: (1) the original caller was dropped (hangup_after_bridge fired on the peer before it joined the conference) — set hangup_after_bridge=false on the peer; (2) callers heard 'only person' + hold music — silence conference_moh_sound + enter/exit sounds on both legs. Both parties now stay in and can keep talking until the agent joins. 🤖 Generated with [Claude Code](https://claude.com/claude-code)