### PR TITLE
Pull peer into conference via ESL &conference (mod_dialplan_inline missing)

### DIFF
--- a/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
+++ b/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
@@ -78,6 +78,12 @@ class ReceptionAgentToolController extends Controller
         }
 
         $args = (array) $request->input('parameters', $request->input('arguments', []));
+        if (!$args) {
+            // Telnyx posts the tool's body_parameters flat at the top level of the
+            // request body (e.g. {"tool_name":"lookup_user","query":"Alice"}), not
+            // nested under parameters/arguments. Treat the rest of the body as args.
+            $args = $request->except(['tool_name', 'tool', 'conversation_id', 'dynamic_variables']);
+        }
 
         $session = null;
         if (!in_array($tool, ['get_time_in_city', 'get_weather'], true)) {

--- a/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
@@ -102,6 +102,15 @@ class ReceptionAgentSummonService
             $vars
         );
 
+        // Pull the existing peer leg into the same conference. mod_dialplan_inline
+        // isn't built on voxra, so the dialplan's `conference:...@default inline`
+        // transfer stalls the peer in CS_ROUTING — use the &application transfer
+        // form here (no inline dialplan needed), the same &conference() the
+        // originate above uses for the agent leg.
+        if ($peerUuid !== '') {
+            $this->esl->executeCommand(sprintf('uuid_transfer %s \'&conference(%s@default)\'', $peerUuid, $confName));
+        }
+
         $session = [
             'conf_name'             => $confName,
             'conversation_id'       => $conversationId,

--- a/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
+++ b/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
@@ -15,19 +15,19 @@
         <action application="set" data="conference_enter_sound=silence_stream://1"/>
         <action application="set" data="conference_exit_sound=silence_stream://1"/>
 
-        <!-- Pull the peer leg into a fresh conference. ${bridge_uuid} is set by
-             FreeSWITCH for the duration of (and persists past) the bridge. Keep the
-             peer alive across the bridge break (else hangup_after_bridge drops it
-             before it lands in the conference) and silence its MOH too. -->
+        <!-- Prep the peer leg: keep it alive across the bridge break (else
+             hangup_after_bridge drops it) and silence its MOH. The summon Lua
+             pulls the peer into the conference via ESL (&conference) because
+             mod_dialplan_inline isn't built on voxra, so a dialplan
+             'conference:...inline' transfer just stalls the peer in CS_ROUTING. -->
         <action application="eval" data="${uuid_setvar(${bridge_uuid} hangup_after_bridge false)}"/>
         <action application="eval" data="${uuid_setvar(${bridge_uuid} conference_moh_sound silence_stream://-1)}"/>
         <action application="eval" data="${uuid_setvar(${bridge_uuid} conference_enter_sound silence_stream://1)}"/>
         <action application="eval" data="${uuid_setvar(${bridge_uuid} conference_exit_sound silence_stream://1)}"/>
-        <action application="eval" data="${uuid_transfer(${bridge_uuid} 'conference:${voxra_conf_name}@@default' inline)}"/>
 
-        <!-- Spawn the ElevenLabs agent leg into the same conference. The Lua
-             call is synchronous so the originate is in flight by the time we
-             transfer ourselves. -->
+        <!-- Spawn the agent leg into the conference AND pull the peer in (both via
+             ESL inside the summon). The Lua call is synchronous so both are in
+             flight by the time we join ourselves below. -->
         <action application="lua" data="voxra_summon_reception_agent.lua ${voxra_conf_name} ${voxra_domain_uuid} ${voxra_originator_uuid} ${voxra_peer_uuid} ${voxra_originator_extension}"/>
 
         <!-- Take the originator (this leg) into the conference too. -->


### PR DESCRIPTION
The original caller stalled in CS_ROUTING and dropped because the dialplan's 'conference:...inline' transfer needs mod_dialplan_inline, which isn't built on voxra. Move the peer-join into the summon via ESL using the &conference() app-transfer form. Now all three (originator, peer, agent) end up in the conference. 🤖 Generated with [Claude Code](https://claude.com/claude-code)