### PR TITLE
Drop endconf so warm transfer completes (814↔811)

### DIFF
--- a/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
+++ b/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
@@ -30,7 +30,11 @@
              flight by the time we join ourselves below. -->
         <action application="lua" data="voxra_summon_reception_agent.lua ${voxra_conf_name} ${voxra_domain_uuid} ${voxra_originator_uuid} ${voxra_peer_uuid} ${voxra_originator_extension}"/>
 
-        <!-- Take the originator (this leg) into the conference too. -->
-        <action application="conference" data="${voxra_conf_name}@@default+flags{endconf}"/>
+        <!-- Take the originator (this leg) into the conference too. No endconf flag:
+             a warm transfer moves the peer out and kills the originator/agent, and
+             endconf on the originator would tear the whole conference down mid-transfer
+             (peer gets SIP 480, target never connects). FreeSWITCH auto-destroys the
+             conference once it empties. -->
+        <action application="conference" data="${voxra_conf_name}@@default"/>
     </condition>
 </extension>


### PR DESCRIPTION
endconf on the originator tore the conference down when the originator was killed during a transfer, so the peer's transfer to the target got SIP 480 and never connected. Remove endconf; FreeSWITCH auto-destroys the empty conference. 🤖 Generated with [Claude Code](https://claude.com/claude-code)