### PR TITLE
fix(reception-agent): silent conference + reliable peer/blind transfer

### DIFF
--- a/app/Http/Controllers/ReceptionAgentController.php
+++ b/app/Http/Controllers/ReceptionAgentController.php
@@ -201,6 +201,8 @@ PROMPT;
 
             $this->generateFeatureCodeDialPlan($agent);
             $this->generateBindMetaAppDialPlan($agent);
+            $this->ensureSilentConferenceProfile();
+            $this->generateConferenceJoinDialPlan($agent);
 
             DB::commit();
 
@@ -344,6 +346,117 @@ PROMPT;
             $dialPlan->dialplan_xml      = $xml;
             $dialPlan->dialplan_name     = $agent->agent_name . ' bind_meta_app';
             $dialPlan->dialplan_enabled  = $agent->agent_enabled;
+            $dialPlan->update_date       = date('Y-m-d H:i:s');
+            $dialPlan->update_user       = session('user_uuid');
+        }
+
+        $dialPlan->save();
+
+        FusionCache::clear('dialplan.' . $domainName);
+    }
+
+    /**
+     * Ensure the global `voxra_recept` conference profile exists. It is a silent
+     * clone of `default`: no alone-sound ("you are the only person…"), no MOH, no
+     * enter/exit beeps — so when *9 is pressed the brief window before the agent
+     * and peer arrive is quiet, and both parties can keep talking. Conference
+     * profiles are global in FusionPBX (no domain_uuid), so this runs once and is
+     * shared by every domain. Idempotent — keyed on profile_name.
+     */
+    private function ensureSilentConferenceProfile(): void
+    {
+        $existing = DB::table('v_conference_profiles')
+            ->where('profile_name', 'voxra_recept')
+            ->value('conference_profile_uuid');
+
+        if ($existing) {
+            return;
+        }
+
+        $profileUuid = (string) Str::uuid();
+        DB::table('v_conference_profiles')->insert([
+            'conference_profile_uuid' => $profileUuid,
+            'profile_name'            => 'voxra_recept',
+            'profile_enabled'         => 'true',
+            'profile_description'     => 'Silent profile for the in-call reception agent (no alone-sound/MOH/beeps)',
+            'insert_date'             => date('Y-m-d H:i:s'),
+        ]);
+
+        // Mirror the stock `default` profile, but silence everything that would
+        // play to a member who is briefly alone or on hold.
+        $params = [
+            'alone-sound'        => '',                        // no "you are the only person"
+            'moh-sound'          => 'silence_stream://-1',     // no hold music
+            'enter-sound'        => '',                        // no enter beep
+            'exit-sound'         => '',                        // no exit beep
+            'comfort-noise'      => 'true',
+            'interval'           => '20',
+            'rate'               => '8000',
+            'energy-level'       => '15',
+            'auto-gain-level'    => '0',
+            'caller-controls'    => 'default',
+            'moderator-controls' => 'moderator',
+        ];
+        $rows = [];
+        foreach ($params as $name => $value) {
+            $rows[] = [
+                'conference_profile_param_uuid' => (string) Str::uuid(),
+                'conference_profile_uuid'       => $profileUuid,
+                'profile_param_name'            => $name,
+                'profile_param_value'           => $value,
+                'profile_param_enabled'         => 'true',
+                'insert_date'                   => date('Y-m-d H:i:s'),
+            ];
+        }
+        DB::table('v_conference_profile_params')->insert($rows);
+    }
+
+    /**
+     * Per-domain dialplan that moves an EXISTING leg into the reception
+     * conference. The summon Lua transfers the held peer here with
+     * `uuid_transfer <peer> <room> XML <domain>`; this extension matches the room
+     * name and joins it. Needed because mod_dialplan_inline isn't built on voxra,
+     * so the `conference:...inline` / `&conference()` transfer forms silently
+     * no-op for existing legs. Idempotent — keyed on dialplan_name + domain.
+     */
+    private function generateConferenceJoinDialPlan(AiAgent $agent): void
+    {
+        $domainName = $agent->domain?->domain_name ?? session('domain_name');
+        $name = 'Voxra Reception Conference Join';
+
+        $xml = sprintf(
+            '<extension name="%s" continue="false" uuid="%%s">' .
+            '<condition field="destination_number" expression="^(voxra_recept_[0-9a-fA-F\-]+)$">' .
+            '<action application="answer" data=""/>' .
+            '<action application="conference" data="$1@voxra_recept"/>' .
+            '</condition></extension>',
+            $name
+        );
+
+        $dialPlan = Dialplans::where('dialplan_name', $name)
+            ->where('domain_uuid', $agent->domain_uuid)
+            ->first();
+
+        if (!$dialPlan) {
+            $uuid = (string) Str::uuid();
+            $dialPlan = new Dialplans();
+            $dialPlan->dialplan_uuid     = $uuid;
+            $dialPlan->app_uuid          = 'b2c48e1a-7f3d-4a1e-9c5b-8d6e7f1a2b3c';
+            $dialPlan->domain_uuid       = $agent->domain_uuid;
+            $dialPlan->dialplan_context  = $domainName;
+            $dialPlan->dialplan_name     = $name;
+            $dialPlan->dialplan_number   = '';
+            $dialPlan->dialplan_continue = 'false';
+            $dialPlan->dialplan_xml      = sprintf($xml, $uuid);
+            $dialPlan->dialplan_order    = 101;
+            $dialPlan->dialplan_enabled  = 'true';
+            $dialPlan->dialplan_description = 'Reception Agent: join existing leg to conference';
+            $dialPlan->insert_date       = date('Y-m-d H:i:s');
+            $dialPlan->insert_user       = session('user_uuid');
+        } else {
+            $dialPlan->dialplan_context  = $domainName;
+            $dialPlan->dialplan_xml      = sprintf($xml, $dialPlan->dialplan_uuid);
+            $dialPlan->dialplan_enabled  = 'true';
             $dialPlan->update_date       = date('Y-m-d H:i:s');
             $dialPlan->update_user       = session('user_uuid');
         }

--- a/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
@@ -97,18 +97,25 @@ class ReceptionAgentSummonService
 
         $this->esl->originate(
             $endpoint,
-            sprintf('&conference(%s@default)', $confName),
+            sprintf('&conference(%s@voxra_recept)', $confName),
             'default',
             $vars
         );
 
-        // Pull the existing peer leg into the same conference. mod_dialplan_inline
-        // isn't built on voxra, so the dialplan's `conference:...@default inline`
-        // transfer stalls the peer in CS_ROUTING — use the &application transfer
-        // form here (no inline dialplan needed), the same &conference() the
-        // originate above uses for the agent leg.
+        // Pull the existing peer leg into the same conference via a real
+        // XML-dialplan transfer to the voxra_recept_join extension (which runs
+        // `conference <room>@voxra_recept`). mod_dialplan_inline isn't built on
+        // voxra, so the `conference:...inline` and `&conference()` transfer forms
+        // both silently no-op — the peer would just sit on hold music after the
+        // originator leaves the bridge. The destination IS the room name, which
+        // the join extension matches with ^(voxra_recept_.+)$.
         if ($peerUuid !== '') {
-            $this->esl->executeCommand(sprintf('uuid_transfer %s \'&conference(%s@default)\'', $peerUuid, $confName));
+            $this->esl->executeCommand(sprintf(
+                'uuid_transfer %s %s XML %s',
+                $peerUuid,
+                $confName,
+                $domainName !== '' ? $domainName : 'default'
+            ));
         }
 
         $session = [

--- a/app/Services/ReceptionAgent/ReceptionAgentToolService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolService.php
@@ -85,29 +85,29 @@ class ReceptionAgentToolService
         }
 
         // Blind transfer: ring the target straight INTO the conference (the
-        // reliable originate path the agent/three-way add already use), then drop
-        // the agent + originator so only the original caller (peer) and the target
-        // remain — effectively a transfer. We deliberately do NOT uuid_transfer the
-        // peer: transferring a live conference member (especially an FMC SIM leg)
-        // stalls ~13s then fails 480.
+        // reliable originate path the agent/three-way add already use). We must
+        // NOT kill the agent + originator here synchronously — originate is async
+        // (bgapi), so killing the conference members in the same breath races the
+        // still-ringing target leg and FreeSWITCH aborts it (instant 503, target
+        // never rings). Instead defer teardown to execute_on_answer: once the
+        // target actually answers and is in the conference, the settle script
+        // kills the agent + originator, leaving the original caller (peer) bridged
+        // to the target. If the target never answers the agent stays live and can
+        // tell the caller.
         $endpoint = sprintf('user/%s@%s', $extension, $domainName ?: '${domain_name}');
         $vars = [
             'origination_caller_id_name'   => 'Reception Transfer',
             'origination_caller_id_number' => $session['originator_extension'] ?? 'reception',
             'voxra_conversation_id'        => $convId,
             'voxra_conf_name'              => $confName,
+            'execute_on_answer'            => sprintf(
+                'lua voxra_blind_settle.lua %s %s %s',
+                $agentUuid !== '' ? $agentUuid : '-',
+                $originatorUuid !== '' ? $originatorUuid : '-',
+                $convId !== '' ? $convId : '-'
+            ),
         ];
-        $this->esl->originate($endpoint, sprintf('&conference(%s@default)', $confName), 'default', $vars);
-
-        if ($agentUuid !== '') {
-            $this->esl->killChannel($agentUuid);
-        }
-        if ($originatorUuid !== '') {
-            $this->esl->killChannel($originatorUuid);
-        }
-        if ($convId !== '') {
-            ReceptionAgentSummonService::deleteSession($convId);
-        }
+        $this->esl->originate($endpoint, sprintf('&conference(%s@voxra_recept)', $confName), 'default', $vars);
 
         return ['ok' => true, 'message' => "Transferring to extension {$extension}"];
     }
@@ -147,7 +147,7 @@ class ReceptionAgentToolService
             'execute_on_answer'            => sprintf('lua voxra_announced_settle.lua %s', $convId),
         ];
 
-        $this->esl->originate($endpoint, sprintf('&conference(%s@default)', $confName), 'default', $vars);
+        $this->esl->originate($endpoint, sprintf('&conference(%s@voxra_recept)', $confName), 'default', $vars);
 
         return ['ok' => true, 'message' => "Calling {$extension} now"];
     }
@@ -175,7 +175,7 @@ class ReceptionAgentToolService
         $domain = (string) ($session['domain_name'] ?? 'default');
         // Originate back: pick up the parked slot and drop into our conference.
         $endpoint = sprintf('loopback/%s/%s', $slot, $domain);
-        $this->esl->originate($endpoint, sprintf('&conference(%s@default)', $confName), 'default', []);
+        $this->esl->originate($endpoint, sprintf('&conference(%s@voxra_recept)', $confName), 'default', []);
         return ['ok' => true, 'message' => "Retrieving call from slot {$slot}"];
     }
 
@@ -187,7 +187,7 @@ class ReceptionAgentToolService
         }
         $domain = (string) ($session['domain_name'] ?? '${domain_name}');
         $endpoint = sprintf('user/%s@%s', $extension, $domain);
-        $this->esl->originate($endpoint, sprintf('&conference(%s@default)', $confName), 'default', [
+        $this->esl->originate($endpoint, sprintf('&conference(%s@voxra_recept)', $confName), 'default', [
             'origination_caller_id_name'   => 'Three-Way',
             'origination_caller_id_number' => $session['originator_extension'] ?? 'reception',
         ]);

--- a/resources/lua/voxra_blind_settle.lua
+++ b/resources/lua/voxra_blind_settle.lua
@@ -1,0 +1,39 @@
+-- voxra_blind_settle.lua
+--
+-- Invoked via execute_on_answer on the blind-transfer target leg the moment the
+-- target picks up and is in the conference. A blind transfer (the agent was
+-- asked "transfer this call to <ext>") means the summoner who pressed *9 is
+-- handing the original caller (peer) over and dropping out, and the AI agent's
+-- job is done. So once — and only once — the target actually answers, we tear
+-- down the agent + originator legs, leaving the peer bridged to the target.
+--
+-- This MUST be deferred to answer-time rather than done synchronously when the
+-- tool fires: the target originate is async (bgapi), so killing the conference
+-- members in the same breath races the still-ringing target and FreeSWITCH
+-- aborts the new leg (instant 503 — the target never rings).
+--
+-- Args (positional; "-" means "skip this one"):
+--   1. agent leg uuid
+--   2. originator (summoner) leg uuid
+--   3. conversation_id (informational / future use)
+
+local SCRIPT_NAME = "[voxra_blind_settle.lua]"
+local api = freeswitch.API()
+
+local function log(level, msg)
+    freeswitch.consoleLog(level, SCRIPT_NAME .. " " .. tostring(msg) .. "\n")
+end
+
+local agent_uuid = argv[1] or "-"
+local orig_uuid  = argv[2] or "-"
+local conv_id    = argv[3] or "-"
+
+log("NOTICE", "settling blind transfer conv=" .. conv_id ..
+    " agent=" .. agent_uuid .. " orig=" .. orig_uuid)
+
+if agent_uuid ~= "" and agent_uuid ~= "-" then
+    api:execute("uuid_kill", agent_uuid)
+end
+if orig_uuid ~= "" and orig_uuid ~= "-" then
+    api:execute("uuid_kill", orig_uuid)
+end

--- a/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
+++ b/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
@@ -8,33 +8,27 @@
         <action application="set" data="voxra_originator_uuid=${uuid}"/>
         <action application="set" data="voxra_peer_uuid=${bridge_uuid}"/>
 
-        <!-- Silence MOH + the "you are the only person" announcement + enter/exit
-             beeps for this leg, so the brief moment before the conference fills is
-             silent rather than music. Both parties stay in and can keep talking. -->
-        <action application="set" data="conference_moh_sound=silence_stream://-1"/>
-        <action application="set" data="conference_enter_sound=silence_stream://1"/>
-        <action application="set" data="conference_exit_sound=silence_stream://1"/>
-
-        <!-- Prep the peer leg: keep it alive across the bridge break (else
-             hangup_after_bridge drops it) and silence its MOH. The summon Lua
-             pulls the peer into the conference via ESL (&conference) because
-             mod_dialplan_inline isn't built on voxra, so a dialplan
-             'conference:...inline' transfer just stalls the peer in CS_ROUTING. -->
+        <!-- Keep the peer leg alive across the bridge break (otherwise its
+             hangup_after_bridge drops it the moment we leave the bridge to join
+             the conference). The summon Lua then pulls the peer into the
+             conference. -->
         <action application="eval" data="${uuid_setvar(${bridge_uuid} hangup_after_bridge false)}"/>
-        <action application="eval" data="${uuid_setvar(${bridge_uuid} conference_moh_sound silence_stream://-1)}"/>
-        <action application="eval" data="${uuid_setvar(${bridge_uuid} conference_enter_sound silence_stream://1)}"/>
-        <action application="eval" data="${uuid_setvar(${bridge_uuid} conference_exit_sound silence_stream://1)}"/>
 
         <!-- Spawn the agent leg into the conference AND pull the peer in (both via
-             ESL inside the summon). The Lua call is synchronous so both are in
-             flight by the time we join ourselves below. -->
+             ESL inside the summon). The peer is moved with a real XML-dialplan
+             transfer to the voxra_recept_join extension — mod_dialplan_inline
+             isn't built on voxra so the 'conference:...inline' and '&conference()'
+             transfer forms silently no-op. The Lua call is synchronous so both
+             are in flight by the time we join ourselves below. -->
         <action application="lua" data="voxra_summon_reception_agent.lua ${voxra_conf_name} ${voxra_domain_uuid} ${voxra_originator_uuid} ${voxra_peer_uuid} ${voxra_originator_extension}"/>
 
-        <!-- Take the originator (this leg) into the conference too. No endconf flag:
-             a warm transfer moves the peer out and kills the originator/agent, and
-             endconf on the originator would tear the whole conference down mid-transfer
-             (peer gets SIP 480, target never connects). FreeSWITCH auto-destroys the
+        <!-- Take the originator (this leg) into the conference too. The
+             voxra_recept profile is silent (no alone-sound / MOH / enter-exit
+             beeps) so the brief moment before the conference fills is quiet, and
+             both parties can keep talking. No endconf flag: a warm transfer moves
+             the peer out and kills the originator/agent, and endconf would tear
+             the whole conference down mid-transfer. FreeSWITCH auto-destroys the
              conference once it empties. -->
-        <action application="conference" data="${voxra_conf_name}@@default"/>
+        <action application="conference" data="${voxra_conf_name}@@voxra_recept"/>
     </condition>
 </extension>


### PR DESCRIPTION
## What

Fixes the three live-test bugs in the `*9` in-call reception agent, all rooted in how legs get placed into the conference.

### 1. Blind transfer never rang the target
`transferCall` originated the target into the conference then **synchronously** killed the agent + originator. `originate` is async (`bgapi`), so the kills raced the still-ringing target leg → FreeSWITCH aborted it (instant 503, target never rang).
**Fix:** defer teardown to `execute_on_answer → voxra_blind_settle.lua` — kill agent + originator only once the target answers, leaving the peer bridged to the target. If the target never answers, the agent stays live to tell the caller.

### 2. Peer left on hold music instead of joining
Summon pulled the peer in with `uuid_transfer <peer> '&conference(room@default)'`, but `mod_dialplan_inline` isn't built on voxra → both `conference:...inline` and `&conference()` transfer forms silently no-op for existing legs.
**Fix:** a real XML-dialplan transfer to a new per-domain **Voxra Reception Conference Join** extension (`^(voxra_recept_.+)$` → `conference $1@voxra_recept`).

### 3. "You are the only person in the conference" + hold music
Channel-var silencing isn't honoured for these (profile-level).
**Fix:** a global silent `voxra_recept` conference profile (empty `alone-sound`, silent `moh-sound`, no enter/exit beeps). `*9` join, summon, transfer, three-way and announced-transfer all use `@voxra_recept`.

Profile + join dialplan are created idempotently during provisioning.

## Test plan
- 814→810, `*9`, "transfer to Alice" → 811 rings, connects, result is 814↔811.
- 816→810, `*9`, "conference in Alice" → 816 stays in conference (no MOH), all three talk.
- No "only person"/hold music before the agent joins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)