### PR TITLE
fix(esl): reconnect dead socket before each command

### DIFF
--- a/app/Services/FreeswitchEslService.php
+++ b/app/Services/FreeswitchEslService.php
@@ -59,6 +59,16 @@ class FreeswitchEslService
     public function executeCommand($cmd, $disconnect = true)
     {
         try {
+            // Self-heal: the socket is disconnected after every command (the
+            // $disconnect default below), so any second command in a multi-step
+            // flow — e.g. originate the agent leg then uuid_transfer the peer into
+            // the conference — would otherwise hit a dead connection and silently
+            // return null ("Call to a member function getBody() on null"). Reopen
+            // it if needed before sending.
+            if (!$this->isConnected()) {
+                $this->reconnect();
+            }
+
             // Send the command and get the response in ESLevent Format
             $eslEvent = $this->conn->api($cmd);
 


### PR DESCRIPTION
## Root cause

`FreeswitchEslService::executeCommand()` disconnects the ESL socket after every call (`$disconnect=true` default). The **second** command in any multi-step flow then hit a dead connection — `$this->conn->api()` returned `null`, the code blew up on `->getBody()`, and the exception was caught and silently swallowed (only `production.DEBUG: Call to a member function getBody() on null` in the log).

This silently broke every reception-agent flow issuing more than one ESL command:
- **Summon**: originates the agent leg (1st — works), then `uuid_transfer`s the held peer into the conference (2nd — **never ran**). The original caller was left on hold music instead of joining.
- **Blind transfer teardown**: the kills after the originate never ran.

(The separate `503`/`480` when calling ext 811 is an unreachable endpoint, confirmed independently — not this bug.)

## Fix

Self-heal at the top of `executeCommand`: if the socket isn't connected, `reconnect()` before sending. Reuses the existing `isConnected()`/`reconnect()` helpers. Benefits every multi-command caller.

## Test plan
- `*9` mid-call → the original caller (peer) joins the conference instead of going to hold music.
- "transfer to <reachable ext>" → target rings and connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)