### PR TITLE
fix(reception-agent): schedule peer conference-join to dodge bridge-teardown race

### DIFF
--- a/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
@@ -106,12 +106,17 @@ class ReceptionAgentSummonService
         // XML-dialplan transfer to the voxra_recept_join extension (which runs
         // `conference <room>@voxra_recept`). mod_dialplan_inline isn't built on
         // voxra, so the `conference:...inline` and `&conference()` transfer forms
-        // both silently no-op — the peer would just sit on hold music after the
-        // originator leaves the bridge. The destination IS the room name, which
-        // the join extension matches with ^(voxra_recept_.+)$.
+        // both silently no-op. The destination IS the room name, which the join
+        // extension matches with ^(voxra_recept_.+)$.
+        //
+        // We SCHEDULE the transfer ~1s out rather than firing it now: pressing *9
+        // tears the A/B bridge down asynchronously, and an immediate uuid_transfer
+        // races that teardown — the peer gets wedged in CS_ROUTING and never joins
+        // (one-way / no audio). Deferring past the teardown lets the peer transfer
+        // cleanly from its settled (post-bridge hold) state into the conference.
         if ($peerUuid !== '') {
             $this->esl->executeCommand(sprintf(
-                'uuid_transfer %s %s XML %s',
+                'sched_transfer +1 %s %s XML %s',
                 $peerUuid,
                 $confName,
                 $domainName !== '' ? $domainName : 'default'


### PR DESCRIPTION
## Root cause

Pressing `*9` runs `execute_extension` on the originator, tearing the A/B bridge down **asynchronously**. The summon then fired `uuid_transfer` on the peer **immediately**, racing that teardown. When the transfer lost the race, the peer wedged in `CS_ROUTING` and never joined the conference — heard but couldn't hear (one-way), until the originator hung up.

Clean single-call trace:
- `.260` peer falls into hold (`playback(local_stream://default)`)
- `.340` `uuid_transfer` peer → `CS_ROUTING`
- `.380` `BRIDGE THREAD DONE` — transfer landed 40 ms *inside* the teardown → stuck in `CS_ROUTING` until hangup, no `conference_member` activation ever.

## Fix

`sched_transfer +1` instead of an immediate `uuid_transfer`, so the peer moves into the conference cleanly from its settled post-bridge state. ~1s of hold before it joins (well under the agent's own join time).

## Test plan
- 811→810, `*9`, "add Bob" → 811 joins with **two-way audio**, all three can talk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)