### PR TITLE
fix(reception-agent): move both call legs into conference with transfer -both

### DIFF
--- a/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
@@ -102,26 +102,13 @@ class ReceptionAgentSummonService
             $vars
         );
 
-        // Pull the existing peer leg into the same conference via a real
-        // XML-dialplan transfer to the voxra_recept_join extension (which runs
-        // `conference <room>@voxra_recept`). mod_dialplan_inline isn't built on
-        // voxra, so the `conference:...inline` and `&conference()` transfer forms
-        // both silently no-op. The destination IS the room name, which the join
-        // extension matches with ^(voxra_recept_.+)$.
-        //
-        // We SCHEDULE the transfer ~1s out rather than firing it now: pressing *9
-        // tears the A/B bridge down asynchronously, and an immediate uuid_transfer
-        // races that teardown — the peer gets wedged in CS_ROUTING and never joins
-        // (one-way / no audio). Deferring past the teardown lets the peer transfer
-        // cleanly from its settled (post-bridge hold) state into the conference.
-        if ($peerUuid !== '') {
-            $this->esl->executeCommand(sprintf(
-                'sched_transfer +1 %s %s XML %s',
-                $peerUuid,
-                $confName,
-                $domainName !== '' ? $domainName : 'default'
-            ));
-        }
+        // NOTE: both original call legs (originator + peer) are moved into the
+        // conference by the *9 dialplan itself via `transfer -both` — NOT here.
+        // bind_meta_app runs the *9 extension as a subroutine while the A/B bridge
+        // is still live, so transferring one leg from here wedged it in CS_ROUTING
+        // and broke the peer's audio. `transfer -both` dissolves the bridge and
+        // routes both parties cleanly into the room. We only originate the agent
+        // leg above.
 
         $session = [
             'conf_name'             => $confName,

--- a/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
+++ b/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
@@ -1,34 +1,21 @@
 <extension name="{{ $agent->agent_name }} reception *9" continue="{{ $dialplan_continue ?? 'false' }}" uuid="{{ $agent->dialplan_uuid }}">
     <condition field="destination_number" expression="^{{ $feature_code }}$">
-        <action application="answer" data=""/>
-        <action application="set" data="hangup_after_bridge=false"/>
         <action application="set" data="voxra_conf_name=voxra_recept_${uuid}"/>
         <action application="set" data="voxra_domain_uuid={{ $agent->domain_uuid }}"/>
         <action application="set" data="voxra_originator_extension=${caller_id_number}"/>
         <action application="set" data="voxra_originator_uuid=${uuid}"/>
         <action application="set" data="voxra_peer_uuid=${bridge_uuid}"/>
 
-        <!-- Keep the peer leg alive across the bridge break (otherwise its
-             hangup_after_bridge drops it the moment we leave the bridge to join
-             the conference). The summon Lua then pulls the peer into the
-             conference. -->
-        <action application="eval" data="${uuid_setvar(${bridge_uuid} hangup_after_bridge false)}"/>
-
-        <!-- Spawn the agent leg into the conference AND pull the peer in (both via
-             ESL inside the summon). The peer is moved with a real XML-dialplan
-             transfer to the voxra_recept_join extension — mod_dialplan_inline
-             isn't built on voxra so the 'conference:...inline' and '&conference()'
-             transfer forms silently no-op. The Lua call is synchronous so both
-             are in flight by the time we join ourselves below. -->
+        <!-- Originate the AI agent leg into the (silent) voxra_recept conference. -->
         <action application="lua" data="voxra_summon_reception_agent.lua ${voxra_conf_name} ${voxra_domain_uuid} ${voxra_originator_uuid} ${voxra_peer_uuid} ${voxra_originator_extension}"/>
 
-        <!-- Take the originator (this leg) into the conference too. The
-             voxra_recept profile is silent (no alone-sound / MOH / enter-exit
-             beeps) so the brief moment before the conference fills is quiet, and
-             both parties can keep talking. No endconf flag: a warm transfer moves
-             the peer out and kills the originator/agent, and endconf would tear
-             the whole conference down mid-transfer. FreeSWITCH auto-destroys the
-             conference once it empties. -->
-        <action application="conference" data="${voxra_conf_name}@@voxra_recept"/>
+        <!-- Move BOTH legs of the live call into the conference in one shot.
+             bind_meta_app runs this *9 extension as a SUBROUTINE while the A/B
+             bridge stays live underneath, so we must not just `conference` here
+             (that nests a conference under the still-bridged call — the peer then
+             loses audio / wedges in CS_ROUTING when moved separately). `transfer
+             -both` dissolves the bridge cleanly and routes BOTH parties to the
+             voxra_recept_join extension, which drops them into the same room. -->
+        <action application="transfer" data="-both ${voxra_conf_name} XML ${domain_name}"/>
     </condition>
 </extension>


### PR DESCRIPTION
Root cause: bind_meta_app runs the *9 extension as a subroutine while the A/B bridge stays live, so `conference` nested under the live bridge and the peer wedged in CS_ROUTING / lost audio. Fix: `transfer -both <room> XML <domain>` dissolves the bridge and routes both parties cleanly into the room. Summon now only originates the agent. 🤖 Generated with [Claude Code](https://claude.com/claude-code)