### PR TITLE
fix(reception-agent): load voxra_*.lua via lua/ symlink path so they persist

### DIFF
--- a/app/Http/Controllers/Internal/ReceptionAgentSummonController.php
+++ b/app/Http/Controllers/Internal/ReceptionAgentSummonController.php
@@ -74,7 +74,7 @@ class ReceptionAgentSummonController extends Controller
             }
 
             if ($originatorUuid !== '' && $peerMemberId !== null) {
-                $hook = sprintf('lua voxra_unmute_member.lua %s %d', $confName, $peerMemberId);
+                $hook = sprintf('lua lua/voxra_unmute_member.lua %s %d', $confName, $peerMemberId);
                 $this->esl->setVar($originatorUuid, 'api_hangup_hook', $hook);
             }
 

--- a/app/Services/ReceptionAgent/ReceptionAgentToolService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolService.php
@@ -101,7 +101,7 @@ class ReceptionAgentToolService
             'voxra_conversation_id'        => $convId,
             'voxra_conf_name'              => $confName,
             'execute_on_answer'            => sprintf(
-                'lua voxra_blind_settle.lua %s %s %s',
+                'lua lua/voxra_blind_settle.lua %s %s %s',
                 $agentUuid !== '' ? $agentUuid : '-',
                 $originatorUuid !== '' ? $originatorUuid : '-',
                 $convId !== '' ? $convId : '-'
@@ -144,7 +144,7 @@ class ReceptionAgentToolService
             'voxra_conf_name'              => $confName,
             // On answer, the settle script reads session state from Redis and
             // performs: mute peer, kill agent, install hangup hook on summoner.
-            'execute_on_answer'            => sprintf('lua voxra_announced_settle.lua %s', $convId),
+            'execute_on_answer'            => sprintf('lua lua/voxra_announced_settle.lua %s', $convId),
         ];
 
         $this->esl->originate($endpoint, sprintf('&conference(%s@voxra_recept)', $confName), 'default', $vars);

--- a/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
+++ b/resources/views/layouts/xml/reception-agent-feature-code-template.blade.php
@@ -7,7 +7,7 @@
         <action application="set" data="voxra_peer_uuid=${bridge_uuid}"/>
 
         <!-- Originate the AI agent leg into the (silent) voxra_recept conference. -->
-        <action application="lua" data="voxra_summon_reception_agent.lua ${voxra_conf_name} ${voxra_domain_uuid} ${voxra_originator_uuid} ${voxra_peer_uuid} ${voxra_originator_extension}"/>
+        <action application="lua" data="lua/voxra_summon_reception_agent.lua ${voxra_conf_name} ${voxra_domain_uuid} ${voxra_originator_uuid} ${voxra_peer_uuid} ${voxra_originator_extension}"/>
 
         <!-- Move BOTH legs of the live call into the conference in one shot.
              bind_meta_app runs this *9 extension as a SUBROUTINE while the A/B


### PR DESCRIPTION
The reception Lua live in `resources/lua/` (symlinked by fspbx's installer to `/usr/share/freeswitch/scripts/lua/`), but were invoked as `lua voxra_*.lua` (no prefix → scripts parent dir), so they only worked via a hand-copy that a rebuild would lose. Now invoked as `lua/voxra_*.lua` (same as push_wake.lua) → resolve through the symlink, persist with the checkout. No ansible/hand-copy needed. 🤖 Generated with [Claude Code](https://claude.com/claude-code)