### PR TITLE
feat(reception-agent): ringback into conference while adding a party

### DIFF
--- a/app/Services/ReceptionAgent/ReceptionAgentToolService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolService.php
@@ -186,10 +186,21 @@ class ReceptionAgentToolService
             return ['ok' => false, 'message' => 'No active conference'];
         }
         $domain = (string) ($session['domain_name'] ?? '${domain_name}');
+
+        // Play UK ringback INTO the conference while the new party rings, so the
+        // existing members hear it ringing instead of silence. The originated
+        // leg stops it on answer (execute_on_answer -> voxra_conf_stop_ringback).
+        // L=30 caps it (~2 min) in case the party never answers.
+        $this->esl->executeCommand(sprintf(
+            'conference %s play tone_stream://L=30;%%(400,200,400,450);%%(400,2000,400,450) async',
+            $confName
+        ));
+
         $endpoint = sprintf('user/%s@%s', $extension, $domain);
         $this->esl->originate($endpoint, sprintf('&conference(%s@voxra_recept)', $confName), 'default', [
             'origination_caller_id_name'   => 'Three-Way',
             'origination_caller_id_number' => $session['originator_extension'] ?? 'reception',
+            'execute_on_answer'            => sprintf('lua lua/voxra_conf_stop_ringback.lua %s', $confName),
         ]);
         return ['ok' => true, 'message' => "Adding {$extension} to the call"];
     }

--- a/resources/lua/voxra_conf_stop_ringback.lua
+++ b/resources/lua/voxra_conf_stop_ringback.lua
@@ -1,0 +1,15 @@
+-- voxra_conf_stop_ringback.lua
+--
+-- Invoked via execute_on_answer on a party being dialed into the reception
+-- conference (e.g. three_way_add "add Bob"). While the party is ringing we play
+-- a ringback tone INTO the conference so the existing members hear it ring
+-- rather than silence; the moment the party answers this stops that playback.
+--
+-- Args:
+--   1. conference room name
+
+local api = freeswitch.API()
+local conf = argv[1] or ""
+if conf ~= "" then
+    api:execute("conference", conf .. " stop all")
+end


### PR DESCRIPTION
When Jarvis adds someone (three_way_add), members heard silence while the new party rang. Now plays UK ringback into the conference during the dial, stopped on answer via execute_on_answer -> lua/voxra_conf_stop_ringback.lua. 🤖 Generated with [Claude Code](https://claude.com/claude-code)