### PR TITLE
feat(reception-agent): summon-by-uuid endpoint for wakeword path

### DIFF
--- a/app/Http/Controllers/Internal/ReceptionAgentSummonController.php
+++ b/app/Http/Controllers/Internal/ReceptionAgentSummonController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Internal;
 
 use App\Http\Controllers\Controller;
+use App\Models\Domain;
 use App\Services\FreeswitchEslService;
 use App\Services\ReceptionAgent\ReceptionAgentSummonService;
 use Illuminate\Http\JsonResponse;
@@ -32,6 +33,62 @@ class ReceptionAgentSummonController extends Controller
             return response()->json(['ok' => true] + $result);
         } catch (Throwable $e) {
             logger()->error('reception-agent summon failed: ' . $e->getMessage());
+            return response()->json(['ok' => false, 'error' => $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * Wakeword path: the openWakeWord service POSTs here when it detects the wake
+     * phrase on a forked call leg. There's no dialplan involved (unlike *9), so we
+     * do the whole merge over ESL: stop the audio fork, originate the AI agent into
+     * a fresh conference, then `uuid_transfer -both` the live call into it. Without
+     * a bind_meta_app subroutine in the way, -both dissolves the bridge cleanly and
+     * routes both parties into the room.
+     */
+    public function summonByUuid(Request $request): JsonResponse
+    {
+        $payload = $request->validate([
+            'uuid'        => 'required|string|max:64',
+            'domain_uuid' => 'required|uuid',
+            'ext'         => 'nullable|string|max:32',
+        ]);
+
+        $uuid = $payload['uuid'];
+
+        $domain = Domain::where('domain_uuid', $payload['domain_uuid'])->first();
+        if (!$domain) {
+            return response()->json(['ok' => false, 'error' => 'unknown domain'], 404);
+        }
+        $domainName = $domain->domain_name;
+
+        // The forked leg is the wakeword-enabled extension; its bridge partner is
+        // the other party on the live call.
+        $peerUuid = (string) ($this->esl->getVar($uuid, 'bridge_uuid') ?? '');
+        $ext = $payload['ext'] ?: (string) ($this->esl->getVar($uuid, 'caller_id_number') ?? '');
+        $confName = 'voxra_recept_' . $uuid;
+
+        try {
+            // Stop the fork so a second "jarvis" mid-summon can't re-fire.
+            $this->esl->executeCommand(sprintf('uuid_audio_stream %s stop', $uuid));
+
+            // Originate the AI agent leg into the (silent) conference.
+            $result = $this->summonService->summon([
+                'conf_name'            => $confName,
+                'domain_uuid'          => $payload['domain_uuid'],
+                'originator_uuid'      => $uuid,
+                'peer_uuid'            => $peerUuid,
+                'originator_extension' => $ext,
+            ]);
+
+            // Move BOTH legs of the live call into the conference.
+            $this->esl->executeCommand(sprintf(
+                'uuid_transfer %s -both %s XML %s',
+                $uuid, $confName, $domainName
+            ));
+
+            return response()->json(['ok' => true] + $result);
+        } catch (Throwable $e) {
+            logger()->error('reception-agent summon-by-uuid failed: ' . $e->getMessage());
             return response()->json(['ok' => false, 'error' => $e->getMessage()], 500);
         }
     }

--- a/app/Services/FreeswitchEslService.php
+++ b/app/Services/FreeswitchEslService.php
@@ -385,6 +385,16 @@ class FreeswitchEslService
         return $this->executeCommand(sprintf('uuid_setvar %s %s %s', $uuid, $name, $value));
     }
 
+    public function getVar(string $uuid, string $name): ?string
+    {
+        $res = $this->executeCommand(sprintf('uuid_getvar %s %s', $uuid, $name));
+        $res = is_string($res) ? trim($res) : '';
+        if ($res === '' || $res === '_undef_' || stripos($res, '-ERR') === 0) {
+            return null;
+        }
+        return $res;
+    }
+
     public function bindMetaApp(string $uuid, string $key, string $action, string $leg = 'a')
     {
         return $this->executeCommand(sprintf("uuid_bind_meta_app %s %s %s s %s", $uuid, $key, $leg, $action));

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,6 +94,9 @@ Route::post('/internal/voxra/reception-agent/summon', [
 Route::post('/internal/voxra/reception-agent/announced-settle', [
     \App\Http\Controllers\Internal\ReceptionAgentSummonController::class, 'announcedSettle',
 ])->middleware(\App\Http\Middleware\VerifyVoxraInternalSignature::class);
+Route::post('/internal/voxra/reception-agent/summon-by-uuid', [
+    \App\Http\Controllers\Internal\ReceptionAgentSummonController::class, 'summonByUuid',
+])->middleware(\App\Http\Middleware\VerifyVoxraInternalSignature::class);
 
 // ElevenLabs Conversational AI tool callbacks (transfer, lookup_user, etc).
 Route::post('/webhooks/voxra/reception-agent/tool', [


### PR DESCRIPTION
openWakeWord service POSTs here on wake-phrase detection. Stops the fork, originates the agent into a fresh conference, then uuid_transfer -both the live call in. Adds ESL getVar + HMAC route. 🤖 Generated with [Claude Code](https://claude.com/claude-code)