### PR TITLE
lookup_user returns live availability (on-hook/off-hook)

### DIFF
--- a/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
@@ -23,7 +23,7 @@ class ReceptionAgentToolDefinitions
         $all = [
             [
                 'name' => 'lookup_user',
-                'description' => 'Find a colleague by name in the directory; returns extension and full name.',
+                'description' => 'Find a colleague by name in the directory. Returns each match with extension, full name, and live availability: status is "available" (free to take a call), "busy" (currently on a call), "offline" (phone off/unreachable), or "unknown". Use this to answer whether someone is available before transferring or adding them.',
                 'properties' => ['query' => ['type' => 'string', 'description' => 'Person name or extension to search for']],
                 'required' => ['query'],
             ],

--- a/app/Services/ReceptionAgent/ReceptionAgentToolService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolService.php
@@ -69,7 +69,75 @@ class ReceptionAgentToolService
             }
         }
 
-        return ['matches' => $matches];
+        return ['matches' => $this->annotateAvailability($matches, (string) ($session['domain_name'] ?? ''))];
+    }
+
+    /**
+     * Tag each lookup match with on-hook/off-hook availability so the agent can
+     * answer "is Alice available?" and decide whether to add/transfer:
+     *   available = registered + not on a call
+     *   busy      = currently on a call (off-hook)
+     *   offline   = not registered (phone off / unreachable)
+     *   unknown   = couldn't read live state
+     */
+    private function annotateAvailability(array $matches, string $domainName): array
+    {
+        if (empty($matches)) {
+            return $matches;
+        }
+
+        // Extensions currently on a call (any leg whose presence_id / caller /
+        // callee is this extension in this domain).
+        $busy = [];
+        try {
+            foreach ($this->esl->getAllChannels() as $ch) {
+                $pid = (string) ($ch['presence_id'] ?? '');
+                if ($pid !== '' && str_ends_with($pid, '@' . $domainName)) {
+                    $busy[strtok($pid, '@')] = true;
+                }
+                foreach (['cid_num', 'callee_num'] as $k) {
+                    $v = (string) ($ch[$k] ?? '');
+                    if ($v !== '' && ctype_digit($v)) {
+                        $busy[$v] = true;
+                    }
+                }
+            }
+        } catch (\Throwable $e) {
+            logger()->warning('lookup availability: getAllChannels failed: ' . $e->getMessage());
+        }
+
+        // Registered extensions (phone on/reachable).
+        $registered = null;
+        try {
+            $registered = [];
+            foreach ($this->esl->getAllSipRegistrations() as $reg) {
+                $u = (string) ($reg['user'] ?? '');
+                if ($u !== '') {
+                    $registered[$u] = true;
+                }
+            }
+        } catch (\Throwable $e) {
+            $registered = null; // unknown
+            logger()->warning('lookup availability: getAllSipRegistrations failed: ' . $e->getMessage());
+        }
+
+        foreach ($matches as &$m) {
+            $ext = (string) ($m['extension'] ?? '');
+            if (isset($busy[$ext])) {
+                $status = 'busy';
+            } elseif ($registered === null) {
+                $status = 'unknown';
+            } elseif (isset($registered[$ext])) {
+                $status = 'available';
+            } else {
+                $status = 'offline';
+            }
+            $m['status'] = $status;
+            $m['available'] = ($status === 'available');
+        }
+        unset($m);
+
+        return $matches;
     }
 
     public function transferCall(array $session, string $extension): array


### PR DESCRIPTION
Annotate lookup matches with availability (available/busy/offline/unknown) from active channels + registrations, so Jarvis can answer 'is Alice available?' and only add/transfer when free. 🤖 Generated with [Claude Code](https://claude.com/claude-code)