### PR TITLE
Fix availability: match registrations by bare extension

### DIFF
--- a/app/Services/ReceptionAgent/ReceptionAgentToolService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolService.php
@@ -111,9 +111,11 @@ class ReceptionAgentToolService
         try {
             $registered = [];
             foreach ($this->esl->getAllSipRegistrations() as $reg) {
+                // 'user' is the full AOR, e.g. "811@iqmobile.uk" — key by the bare
+                // extension within this domain so it matches the lookup rows.
                 $u = (string) ($reg['user'] ?? '');
-                if ($u !== '') {
-                    $registered[$u] = true;
+                if ($u !== '' && str_ends_with($u, '@' . $domainName)) {
+                    $registered[strtok($u, '@')] = true;
                 }
             }
         } catch (\Throwable $e) {


### PR DESCRIPTION
getAllSipRegistrations returns full AORs; key the registered set by bare extension for the domain so availability isn't always 'offline'. 🤖 Generated with [Claude Code](https://claude.com/claude-code)