### PR TITLE
Telnyx tool identity from URL path (fix 422 tool_name required)

### DIFF
--- a/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
+++ b/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
@@ -61,7 +61,9 @@ class ReceptionAgentToolController extends Controller
 
     public function handle(Request $request): JsonResponse
     {
-        $tool = (string) $request->input('tool_name', $request->input('tool', ''));
+        // Prefer the tool name from the URL path (reliable); fall back to the body
+        // for older/bare-route calls.
+        $tool = (string) ($request->route('tool') ?: $request->input('tool_name', $request->input('tool', '')));
         if ($tool === '') {
             return response()->json(['ok' => false, 'error' => 'tool_name required'], 422);
         }

--- a/app/Services/TelnyxConvaiService.php
+++ b/app/Services/TelnyxConvaiService.php
@@ -125,7 +125,9 @@ class TelnyxConvaiService
                 'webhook' => [
                     'name' => $t['name'],
                     'description' => $t['description'],
-                    'url' => $toolUrl,
+                    // Tool name in the path — robust against the LLM omitting it
+                    // from the body (causes a 422 'tool_name required').
+                    'url' => $toolUrl . '/' . $t['name'],
                     'method' => 'POST',
                     'headers' => [
                         ['name' => 'Content-Type', 'value' => 'application/json'],

--- a/routes/web.php
+++ b/routes/web.php
@@ -108,6 +108,12 @@ Route::post('/webhooks/voxra/reception-agent/tool', [
 // short-lived) conversation_id session, and dynamic-variables only echoes a
 // conversation_id when given a valid caller-id correlation token.
 // TODO(hardening): add Telnyx Ed25519 signature verification before broad prod use.
+// Per-tool URL: the tool name is in the path so we never depend on the LLM
+// echoing tool_name in the body (it often omits it -> 422). Keep the bare route
+// too for backwards compatibility.
+Route::post('/webhooks/voxra/reception-agent/tool-telnyx/{tool}', [
+    \App\Http\Controllers\Webhooks\ReceptionAgentToolController::class, 'handle',
+]);
 Route::post('/webhooks/voxra/reception-agent/tool-telnyx', [
     \App\Http\Controllers\Webhooks\ReceptionAgentToolController::class, 'handle',
 ]);


### PR DESCRIPTION
All tools POST to one URL and the dispatcher needed tool_name in the body, which the LLM omits (complete_and_exit 422'd). Put the tool name in the URL path and read it from the route. 🤖 Generated with [Claude Code](https://claude.com/claude-code)