### PR TITLE
Fix wakeword toggle: extension_setting_enabled is boolean

### DIFF
--- a/app/Models/ExtensionSetting.php
+++ b/app/Models/ExtensionSetting.php
@@ -31,6 +31,11 @@ class ExtensionSetting extends Model
         'insert_user',
     ];
 
+    // extension_setting_enabled is a Postgres boolean column.
+    protected $casts = [
+        'extension_setting_enabled' => 'boolean',
+    ];
+
     protected static function booted()
     {
         static::creating(function ($model) {

--- a/app/Models/Extensions.php
+++ b/app/Models/Extensions.php
@@ -271,7 +271,7 @@ class Extensions extends Model
         $row = $this->settings
             ->firstWhere(fn ($s) => $s->extension_setting_type === 'variable'
                 && $s->extension_setting_name === $name
-                && $s->extension_setting_enabled === 'true');
+                && $s->extension_setting_enabled === true);
 
         return $row?->extension_setting_value;
     }
@@ -291,7 +291,7 @@ class Extensions extends Model
             if ($existing) {
                 $existing->update([
                     'extension_setting_value'   => $value,
-                    'extension_setting_enabled' => 'true',
+                    'extension_setting_enabled' => true,
                 ]);
             } else {
                 $this->settings()->create([
@@ -299,7 +299,7 @@ class Extensions extends Model
                     'extension_setting_type'    => 'variable',
                     'extension_setting_name'    => $name,
                     'extension_setting_value'   => $value,
-                    'extension_setting_enabled' => 'true',
+                    'extension_setting_enabled' => true,
                     'extension_setting_description' => 'Managed by the extension form',
                     'insert_date'               => now(),
                 ]);


### PR DESCRIPTION
extension_setting_enabled is a Postgres boolean; cast it and compare/write a real bool so the wakeword toggle reads/writes correctly. 🤖 Generated with [Claude Code](https://claude.com/claude-code)