### PR TITLE
Add Telnyx UK number provisioning (#19)

### DIFF
--- a/app/Console/Commands/ProvisionNumber.php
+++ b/app/Console/Commands/ProvisionNumber.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\TelnyxNumberService;
+use Illuminate\Console\Command;
+
+/**
+ * Search and order UK numbers from Telnyx (voxragtm#19).
+ *
+ * Examples:
+ *   # See what's available in London (020) without ordering:
+ *   php artisan numbers:provision --area-code=20 --search-only
+ *
+ *   # Order one London number and attach it to a Telnyx connection:
+ *   php artisan numbers:provision --area-code=20 --connection=1234567890
+ *
+ * Associating the ordered number with a tenant's dialplan/destinations is a
+ * follow-up (voxragtm#23) and is intentionally not done here.
+ */
+class ProvisionNumber extends Command
+{
+    protected $signature = 'numbers:provision
+        {--country=GB : ISO country code}
+        {--type=local : local|national|toll_free|mobile}
+        {--area-code= : national destination code, e.g. 20 for London, 161 for Manchester}
+        {--quantity=1 : how many numbers to order}
+        {--connection= : Telnyx connection_id to attach the number(s) to}
+        {--messaging-profile= : Telnyx messaging_profile_id for SMS/WhatsApp}
+        {--search-only : list matches and exit without ordering}
+        {--dry-run : resolve matches and show the order that WOULD be placed}';
+
+    protected $description = 'Search and order UK phone numbers from Telnyx.';
+
+    public function handle(TelnyxNumberService $numbers): int
+    {
+        $quantity = max(1, (int) $this->option('quantity'));
+
+        $matches = $numbers->searchAvailable([
+            'country'   => (string) $this->option('country'),
+            'type'      => (string) $this->option('type'),
+            'area_code' => (string) ($this->option('area-code') ?: ''),
+            'limit'     => max($quantity, 10),
+        ]);
+
+        if ($matches === []) {
+            $this->error('No available numbers matched those filters.');
+
+            return self::FAILURE;
+        }
+
+        $this->table(
+            ['Number', 'Region', 'Locality', 'Upfront', 'Monthly'],
+            array_map(fn (array $n) => [
+                $n['phone_number'],
+                $n['region'] ?? '—',
+                $n['locality'] ?? '—',
+                $n['upfront_cost'] ?? '—',
+                $n['monthly_cost'] ?? '—',
+            ], $matches),
+        );
+
+        if ($this->option('search-only')) {
+            return self::SUCCESS;
+        }
+
+        $selected = array_slice(array_column($matches, 'phone_number'), 0, $quantity);
+
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — would order: ' . implode(', ', $selected));
+
+            return self::SUCCESS;
+        }
+
+        $this->info('Ordering: ' . implode(', ', $selected));
+
+        $order = $numbers->createOrder(
+            $selected,
+            (string) $this->option('connection') ?: null,
+            (string) $this->option('messaging-profile') ?: null,
+        );
+
+        $this->info("Order {$order['id']} created — status: {$order['status']}");
+        $this->line('Number orders settle asynchronously; poll with the Telnyx dashboard or getOrder().');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/TelnyxNumberService.php
+++ b/app/Services/TelnyxNumberService.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Services;
+
+use RuntimeException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\ConnectionException;
+
+/**
+ * Thin client for the Telnyx phone-number provisioning APIs — searching the
+ * inventory of available UK numbers and placing number orders.
+ *
+ * This is the "get a number" half of Voxra provisioning (voxragtm#19). It is
+ * deliberately separate from {@see \App\Services\PhoneNumberService}, which
+ * builds the in-PBX routing/destination config once a number exists. Wiring an
+ * ordered number into a tenant's dialplan/destinations is a follow-up
+ * (voxragtm#23) and must go through CallRoutingOptionsService per repo
+ * conventions.
+ *
+ * Mirrors {@see \App\Services\TelnyxConvaiService}: same config keys, bearer
+ * auth, JSON headers and retry policy.
+ */
+class TelnyxNumberService
+{
+    private string $apiKey;
+    private string $baseUrl;
+    private int $timeout;
+
+    public function __construct()
+    {
+        $this->apiKey  = (string) config('services.telnyx.api_key', '');
+        $this->baseUrl = rtrim((string) config('services.telnyx.base_url', 'https://api.telnyx.com'), '/');
+        $this->timeout = (int) config('services.telnyx.timeout', 60);
+
+        if ($this->apiKey === '') {
+            throw new RuntimeException('Telnyx API key is not configured. Please set TELNYX_API_KEY in your environment file.');
+        }
+    }
+
+    /**
+     * Search the available-number inventory.
+     * GET /v2/available_phone_numbers
+     *
+     * @param  array{country?:string,type?:string,area_code?:string,features?:array<int,string>,limit?:int}  $opts
+     * @return array<int,array{phone_number:string,region:?string,locality:?string,upfront_cost:?string,monthly_cost:?string}>
+     */
+    public function searchAvailable(array $opts = []): array
+    {
+        $filter = array_filter([
+            'country_code'             => strtoupper((string) ($opts['country'] ?? 'GB')),
+            'phone_number_type'        => (string) ($opts['type'] ?? 'local'),
+            'national_destination_code' => $opts['area_code'] ?? null,
+            'features'                 => $opts['features'] ?? ['voice', 'sms'],
+            'limit'                    => (int) ($opts['limit'] ?? 10),
+        ], fn ($v) => $v !== null && $v !== '');
+
+        $response = $this->http()->get('v2/available_phone_numbers', ['filter' => $filter]);
+
+        if (!$response->successful()) {
+            logger('Telnyx available-number search error: ' . $response->body());
+            throw new RuntimeException('Failed to search Telnyx numbers: ' . $this->errorDetail($response));
+        }
+
+        return collect($response->json('data') ?? [])
+            ->map(fn (array $n) => [
+                'phone_number' => $n['phone_number'] ?? '',
+                'region'       => $n['region_information'][0]['region_name'] ?? null,
+                'locality'     => $n['region_information'][1]['region_name'] ?? null,
+                'upfront_cost' => $n['cost_information']['upfront_cost'] ?? null,
+                'monthly_cost' => $n['cost_information']['monthly_cost'] ?? null,
+            ])
+            ->filter(fn (array $n) => $n['phone_number'] !== '')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Place an order for one or more numbers.
+     * POST /v2/number_orders
+     *
+     * @param  array<int,string>  $phoneNumbers  E.164 numbers, e.g. ['+442071234567']
+     * @return array{id:?string,status:?string,phone_numbers:array<int,mixed>}
+     */
+    public function createOrder(array $phoneNumbers, ?string $connectionId = null, ?string $messagingProfileId = null): array
+    {
+        if ($phoneNumbers === []) {
+            throw new RuntimeException('createOrder requires at least one phone number.');
+        }
+
+        $body = array_filter([
+            'phone_numbers'        => array_map(fn (string $n) => ['phone_number' => $n], array_values($phoneNumbers)),
+            'connection_id'        => $connectionId,
+            'messaging_profile_id' => $messagingProfileId,
+        ], fn ($v) => $v !== null);
+
+        $response = $this->http()->post('v2/number_orders', $body);
+
+        if (!$response->successful()) {
+            logger('Telnyx number-order error: ' . $response->body());
+            throw new RuntimeException('Failed to create Telnyx number order: ' . $this->errorDetail($response));
+        }
+
+        $data = $response->json('data') ?? [];
+
+        return [
+            'id'            => $data['id'] ?? null,
+            'status'        => $data['status'] ?? null,
+            'phone_numbers' => $data['phone_numbers'] ?? [],
+        ];
+    }
+
+    /**
+     * Fetch the current state of a number order (orders settle asynchronously).
+     * GET /v2/number_orders/{id}
+     */
+    public function getOrder(string $orderId): array
+    {
+        $response = $this->http()->get("v2/number_orders/{$orderId}");
+
+        if (!$response->successful()) {
+            throw new RuntimeException('Failed to fetch Telnyx number order: ' . $this->errorDetail($response));
+        }
+
+        return $response->json('data') ?? [];
+    }
+
+    private function errorDetail(\Illuminate\Http\Client\Response $response): string
+    {
+        $errors = $response->json('errors');
+        if (is_array($errors) && !empty($errors)) {
+            return collect($errors)
+                ->map(fn ($e) => trim(($e['title'] ?? '') . ': ' . ($e['detail'] ?? '')))
+                ->implode('; ');
+        }
+
+        return $response->body();
+    }
+
+    private function http(): \Illuminate\Http\Client\PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl . '/')
+            ->timeout($this->timeout)
+            ->withToken($this->apiKey)
+            ->withHeaders([
+                'Content-Type' => 'application/json',
+                'Accept'       => 'application/json',
+            ])
+            ->retry(
+                3,
+                500,
+                function ($exception) {
+                    if ($exception instanceof ConnectionException) {
+                        return true;
+                    }
+                    $response = method_exists($exception, 'response') ? $exception->response() : null;
+                    $status = $response?->status();
+                    return in_array($status, [429, 500, 502, 503, 504], true);
+                },
+                throw: false
+            );
+    }
+}

--- a/tests/Feature/TelnyxNumberServiceTest.php
+++ b/tests/Feature/TelnyxNumberServiceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\TelnyxNumberService;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Tests\TestCase;
+
+class TelnyxNumberServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('services.telnyx.api_key', 'KEY_test');
+        config()->set('services.telnyx.base_url', 'https://api.telnyx.com');
+    }
+
+    public function test_it_requires_an_api_key(): void
+    {
+        config()->set('services.telnyx.api_key', '');
+        $this->expectException(RuntimeException::class);
+        new TelnyxNumberService();
+    }
+
+    public function test_search_maps_available_numbers_and_sends_bearer_token(): void
+    {
+        Http::fake([
+            'api.telnyx.com/v2/available_phone_numbers*' => Http::response([
+                'data' => [
+                    [
+                        'phone_number' => '+442071234567',
+                        'region_information' => [
+                            ['region_name' => 'GB'],
+                            ['region_name' => 'London'],
+                        ],
+                        'cost_information' => ['upfront_cost' => '1.00', 'monthly_cost' => '1.00'],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $results = (new TelnyxNumberService())->searchAvailable([
+            'country' => 'GB',
+            'type' => 'local',
+            'area_code' => '20',
+            'limit' => 5,
+        ]);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('+442071234567', $results[0]['phone_number']);
+        $this->assertSame('London', $results[0]['locality']);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/v2/available_phone_numbers')
+                && $request->hasHeader('Authorization', 'Bearer KEY_test');
+        });
+    }
+
+    public function test_create_order_posts_numbers_and_returns_status(): void
+    {
+        Http::fake([
+            'api.telnyx.com/v2/number_orders' => Http::response([
+                'data' => [
+                    'id' => 'ord_123',
+                    'status' => 'pending',
+                    'phone_numbers' => [['phone_number' => '+442071234567']],
+                ],
+            ], 200),
+        ]);
+
+        $order = (new TelnyxNumberService())->createOrder(
+            ['+442071234567'],
+            'conn_1',
+            'msg_1',
+        );
+
+        $this->assertSame('ord_123', $order['id']);
+        $this->assertSame('pending', $order['status']);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/v2/number_orders')
+                && $request['connection_id'] === 'conn_1'
+                && $request['messaging_profile_id'] === 'msg_1'
+                && $request['phone_numbers'][0]['phone_number'] === '+442071234567';
+        });
+    }
+
+    public function test_search_throws_on_api_error(): void
+    {
+        Http::fake([
+            'api.telnyx.com/v2/available_phone_numbers*' => Http::response([
+                'errors' => [['title' => 'Bad request', 'detail' => 'invalid filter']],
+            ], 422),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        (new TelnyxNumberService())->searchAvailable(['area_code' => 'xx']);
+    }
+}


### PR DESCRIPTION
Implements the "get a number" half of Voxra provisioning — searching Telnyx's UK inventory and placing number orders (ystwythv/voxragtm#19).

## What's added
- **`App\Services\TelnyxNumberService`** — `searchAvailable()` (GET `/v2/available_phone_numbers`), `createOrder()` (POST `/v2/number_orders`), `getOrder()`. Mirrors `TelnyxConvaiService` exactly: same `services.telnyx.*` config, bearer auth, JSON headers, retry policy.
- **`numbers:provision`** artisan command — search-only / dry-run / order, with `--country --type --area-code --quantity --connection --messaging-profile`.
- **Feature test** (`Http::fake`) covering response mapping, order body shape, bearer header and API-error handling.

## Scope / boundaries
- Complements `PhoneNumberService` (which only builds in-PBX routing/destination data) — no overlap.
- **Does not** wire an ordered number into a tenant's dialplan/destinations — that goes through `CallRoutingOptionsService` per repo conventions and is tracked separately (voxragtm#23).
- Uses the existing `TELNYX_API_KEY` config; no env/secret changes.

## ⚠️ Testing
Authored in an environment with **no PHP runtime** — the test was **not executed locally**. Please let CI / a PHP 8.4 env run `tests/Feature/TelnyxNumberServiceTest.php` before merge.

Part of ystwythv/voxragtm#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)