### PR TITLE
FMC no-answer → reception agent, with a tool session (#23)

### DIFF
--- a/app/Console/Commands/RouteExtensionToAgent.php
+++ b/app/Console/Commands/RouteExtensionToAgent.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\AiAgent;
+use App\Models\Domain;
+use App\Models\Extensions;
+use App\Models\FusionCache;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+/**
+ * Point an FMC extension's no-answer / busy / unregistered failover at the
+ * domain's reception agent, so a missed call goes to the AI agent instead of
+ * voicemail (voxragtm#23). Idempotent; `--disable` clears the three forwards.
+ *
+ *   php artisan reception-agent:route-extension acme.voxra.uk 1001
+ *   php artisan reception-agent:route-extension acme.voxra.uk 1001 --disable
+ */
+class RouteExtensionToAgent extends Command
+{
+    protected $signature = 'reception-agent:route-extension
+        {domain : domain_name or domain_uuid}
+        {extension : the FMC extension number}
+        {--disable : clear the agent failover instead of setting it}';
+
+    protected $description = "Route an extension's no-answer/busy/unregistered failover to the domain reception agent (voxragtm#23).";
+
+    public function handle(): int
+    {
+        $domainArg = (string) $this->argument('domain');
+        $domain = Str::isUuid($domainArg)
+            ? Domain::where('domain_uuid', $domainArg)->first()
+            : Domain::where('domain_name', $domainArg)->first();
+
+        if (!$domain) {
+            $this->error("Domain not found: {$domainArg}");
+            return self::FAILURE;
+        }
+
+        $extension = Extensions::where('domain_uuid', $domain->domain_uuid)
+            ->where('extension', (string) $this->argument('extension'))
+            ->first();
+
+        if (!$extension) {
+            $this->error("Extension {$this->argument('extension')} not found in {$domain->domain_name}");
+            return self::FAILURE;
+        }
+
+        $disable = (bool) $this->option('disable');
+
+        if ($disable) {
+            $extension->forward_no_answer_enabled = 'false';
+            $extension->forward_busy_enabled = 'false';
+            $extension->forward_user_not_registered_enabled = 'false';
+            $extension->save();
+            $this->clearCache($extension, $domain->domain_name);
+            $this->info("Cleared agent failover on extension {$extension->extension}.");
+            return self::SUCCESS;
+        }
+
+        $agent = AiAgent::reception()
+            ->forDomain($domain->domain_uuid)
+            ->where('agent_enabled', 'true')
+            ->first();
+
+        if (!$agent || !$agent->agent_extension) {
+            $this->error("No enabled reception agent for {$domain->domain_name} — provision one first (reception-agent:provision).");
+            return self::FAILURE;
+        }
+
+        $target = (string) $agent->agent_extension;
+
+        $extension->forward_no_answer_enabled = 'true';
+        $extension->forward_no_answer_destination = $target;
+        $extension->forward_busy_enabled = 'true';
+        $extension->forward_busy_destination = $target;
+        $extension->forward_user_not_registered_enabled = 'true';
+        $extension->forward_user_not_registered_destination = $target;
+        $extension->save();
+
+        $this->clearCache($extension, $domain->domain_name);
+
+        $this->info("Extension {$extension->extension}: no-answer/busy/unregistered → reception agent {$target}.");
+        return self::SUCCESS;
+    }
+
+    private function clearCache(Extensions $extension, string $domainName): void
+    {
+        $context = $extension->user_context ?: $domainName;
+        FusionCache::clear("directory:{$extension->extension}@{$context}");
+        FusionCache::clear('dialplan.' . $domainName);
+    }
+}

--- a/app/Http/Controllers/ReceptionAgentController.php
+++ b/app/Http/Controllers/ReceptionAgentController.php
@@ -200,6 +200,7 @@ PROMPT;
             $provider->syncReceptionAgentTools($agent);
 
             $this->generateFeatureCodeDialPlan($agent);
+            $this->generateInboundReceptionDialPlan($agent);
             $this->generateBindMetaAppDialPlan($agent);
             $this->ensureSilentConferenceProfile();
             $this->generateConferenceJoinDialPlan($agent);
@@ -292,6 +293,74 @@ PROMPT;
             $dialPlan->update_user      = session('user_uuid');
         }
 
+        $dialPlan->save();
+
+        FusionCache::clear('dialplan.' . $domainName);
+    }
+
+    private const INBOUND_DIALPLAN_DESCRIPTION = 'Reception Agent inbound answer';
+
+    /**
+     * Reception agent as an inbound answer target (voxragtm#23). Creates a
+     * dialplan on the agent's extension that answers a direct inbound call
+     * (e.g. an FMC no-answer failover routed via the `ai_agents` destination) and
+     * bridges to the Telnyx assistant with the reception session headers, so the
+     * qualify/book tools work on a call the caller reached without pressing *9.
+     * Telnyx-only; no-op otherwise. Upserts by (domain_uuid, agent_extension).
+     */
+    private function generateInboundReceptionDialPlan(AiAgent $agent): void
+    {
+        if (
+            $agent->provider !== AiAgent::PROVIDER_TELNYX
+            || empty($agent->telnyx_assistant_id)
+            || empty($agent->agent_extension)
+        ) {
+            return;
+        }
+
+        $domainName = $agent->domain?->domain_name ?? session('domain_name');
+
+        $existing = Dialplans::where('domain_uuid', $agent->domain_uuid)
+            ->where('dialplan_number', $agent->agent_extension)
+            ->where('dialplan_description', self::INBOUND_DIALPLAN_DESCRIPTION)
+            ->first();
+
+        $dialplanUuid = $existing?->dialplan_uuid ?? (string) Str::uuid();
+
+        $xml = trim(view('layouts.xml.telnyx-ai-agent-inbound-reception-template', [
+            'agent'             => $agent,
+            'dialplan_uuid'     => $dialplanUuid,
+            'attach_domain'     => config('services.telnyx.attach_domain'),
+            'dialplan_continue' => 'false',
+        ])->render());
+
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->loadXML($xml);
+        $dom->formatOutput = true;
+        $xml = $dom->saveXML($dom->documentElement);
+
+        $dialPlan = $existing ?? new Dialplans();
+
+        if (!$existing) {
+            $dialPlan->dialplan_uuid        = $dialplanUuid;
+            $dialPlan->app_uuid             = 'b2c48e1a-7f3d-4a1e-9c5b-8d6e7f1a2b3c';
+            $dialPlan->domain_uuid          = $agent->domain_uuid;
+            $dialPlan->dialplan_number      = $agent->agent_extension;
+            $dialPlan->dialplan_order       = 101;
+            $dialPlan->dialplan_description = self::INBOUND_DIALPLAN_DESCRIPTION;
+            $dialPlan->insert_date          = date('Y-m-d H:i:s');
+            $dialPlan->insert_user          = session('user_uuid');
+        } else {
+            $dialPlan->update_date          = date('Y-m-d H:i:s');
+            $dialPlan->update_user          = session('user_uuid');
+        }
+
+        $dialPlan->dialplan_context  = $domainName;
+        $dialPlan->dialplan_name     = $agent->agent_name . ' inbound';
+        $dialPlan->dialplan_continue = 'false';
+        $dialPlan->dialplan_xml      = $xml;
+        $dialPlan->dialplan_enabled  = $agent->agent_enabled;
         $dialPlan->save();
 
         FusionCache::clear('dialplan.' . $domainName);

--- a/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
+++ b/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
@@ -49,6 +49,20 @@ class ReceptionAgentToolController extends Controller
                 : '';
         }
 
+        // Inbound FMC calls (voxragtm#23) reach the agent directly (no *9 summon),
+        // so no session exists yet. They carry the tenant + caller as voxra_*
+        // headers surfaced here; bootstrap a minimal session so the qualify/book
+        // tools can resolve the domain.
+        $domainUuid = (string) ($payload['voxra_domain_uuid'] ?? '');
+        if ($conversationId !== '' && $domainUuid !== '') {
+            $caller = (string) ($payload['voxra_caller_number'] ?? $payload['telnyx_end_user_target'] ?? '');
+            try {
+                ReceptionAgentSummonService::ensureInboundSession($domainUuid, $conversationId, $caller);
+            } catch (\Throwable $e) {
+                logger()->warning('reception-agent inbound session bootstrap failed: ' . $e->getMessage());
+            }
+        }
+
         logger()->info('reception-agent dynamic-variables', [
             'resolved'     => $conversationId,
             'payload_keys' => array_keys($payload),

--- a/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentSummonService.php
@@ -158,6 +158,42 @@ class ReceptionAgentSummonService
         );
     }
 
+    /**
+     * Bootstrap a minimal reception session for a *direct inbound* call (FMC
+     * no-answer → agent, voxragtm#23). Unlike summon() there is no conference or
+     * peer — just the caller and the agent — so the session only needs the
+     * tenant + conversation + caller so the qualify/book tools resolve the domain
+     * and repeat-caller recognition works. No-op if a session already exists.
+     *
+     * @return array the existing or newly-created session
+     */
+    public static function ensureInboundSession(
+        string $domainUuid,
+        string $conversationId,
+        ?string $callerNumber = null,
+    ): array {
+        if ($domainUuid === '' || $conversationId === '') {
+            throw new RuntimeException('ensureInboundSession: domain_uuid and conversation_id required');
+        }
+
+        $existing = self::loadSession($conversationId);
+        if ($existing) {
+            return $existing;
+        }
+
+        $session = [
+            'conversation_id' => $conversationId,
+            'domain_uuid'     => $domainUuid,
+            'caller_number'   => $callerNumber !== '' ? $callerNumber : null,
+            'source'          => 'inbound_reception',
+            'created_at'      => now()->toIso8601String(),
+        ];
+
+        self::saveSession($conversationId, $session);
+
+        return $session;
+    }
+
     public static function deleteSession(string $conversationId): void
     {
         $session = self::loadSession($conversationId);

--- a/resources/views/layouts/xml/telnyx-ai-agent-inbound-reception-template.blade.php
+++ b/resources/views/layouts/xml/telnyx-ai-agent-inbound-reception-template.blade.php
@@ -1,0 +1,33 @@
+<extension name="{{ $agent->agent_name }} inbound reception" continue="{{ $dialplan_continue ?? 'false' }}" uuid="{{ $dialplan_uuid }}">
+    <condition field="destination_number" expression="^{{ $agent->agent_extension }}$">
+        <action application="ring_ready" data="" />
+        <action application="answer" data="" />
+        <action application="sleep" data="1000" />
+        <action application="set" data="hangup_after_bridge=true" />
+        {{-- a failed SIP-attach bridge must fall through to the subdomain bridge --}}
+        <action application="set" data="continue_on_fail=true" />
+        <action application="set" data="absolute_codec_string=PCMU,PCMA" />
+        <action application="set" data="ringback=$${uk-ring}" />
+        <action application="set" data="transfer_ringback=$${uk-ring}" />
+        <action application="set" data="ignore_early_media=true" />
+        <action application="set" data="ai_agent_uuid={{ $agent->ai_agent_uuid }}" />
+
+        {{-- Reception session context. The inbound call's own uuid is the
+             conversation id. Telnyx surfaces these X-Voxra-* INVITE headers as
+             voxra_* fields on assistant.initialization, where dynamicVariables()
+             bootstraps the Redis session so the qualify/book tools can resolve
+             the tenant (voxragtm#23/#28/#29). --}}
+        <action application="set" data="voxra_domain_uuid={{ $agent->domain_uuid }}" />
+        <action application="set" data="voxra_conversation_id=${uuid}" />
+        <action application="set" data="voxra_caller_number=${caller_id_number}" />
+@php
+    $voxraHeaders = '{sip_h_X-Voxra-Conversation-Id=${uuid},sip_h_X-Voxra-Domain-Uuid=' . $agent->domain_uuid . ',sip_h_X-Voxra-Caller-Number=${caller_id_number}}';
+@endphp
+@if (!empty($agent->telnyx_attach_extension) && !empty($attach_domain))
+        {{-- SIP attach: Telnyx registers this extension into the attach domain.
+             Falls through to the public assistant subdomain if unregistered. --}}
+        <action application="bridge" data="{{ $voxraHeaders }}user/{{ $agent->telnyx_attach_extension . '@' . $attach_domain }}" />
+@endif
+        <action application="bridge" data="{{ $voxraHeaders }}sofia/external/sip:{{ 'agent@' . $agent->telnyx_assistant_id }}.sip.telnyx.com" />
+    </condition>
+</extension>

--- a/tests/Feature/ReceptionInboundSessionTest.php
+++ b/tests/Feature/ReceptionInboundSessionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\ReceptionAgent\ReceptionAgentSummonService;
+use Illuminate\Support\Facades\Redis;
+use Tests\TestCase;
+
+/**
+ * ReceptionAgentSummonService::ensureInboundSession — the session bootstrap for
+ * a direct inbound (FMC no-answer) call so the qualify/book tools resolve the
+ * tenant without a *9 summon. (voxragtm#23)
+ */
+class ReceptionInboundSessionTest extends TestCase
+{
+    public function test_creates_a_minimal_session_when_none_exists(): void
+    {
+        Redis::shouldReceive('get')->once()->andReturn(null);
+        Redis::shouldReceive('setex')->once();
+
+        $session = ReceptionAgentSummonService::ensureInboundSession(
+            'domain-uuid-1',
+            'conv-1',
+            '+447700900123',
+        );
+
+        $this->assertSame('domain-uuid-1', $session['domain_uuid']);
+        $this->assertSame('conv-1', $session['conversation_id']);
+        $this->assertSame('+447700900123', $session['caller_number']);
+        $this->assertSame('inbound_reception', $session['source']);
+    }
+
+    public function test_is_idempotent_and_preserves_an_existing_session(): void
+    {
+        $existing = json_encode([
+            'domain_uuid' => 'domain-uuid-1',
+            'conversation_id' => 'conv-1',
+            'source' => 'inbound_reception',
+        ]);
+        Redis::shouldReceive('get')->once()->andReturn($existing);
+        Redis::shouldReceive('setex')->never();
+
+        $session = ReceptionAgentSummonService::ensureInboundSession(
+            'domain-uuid-DIFFERENT',
+            'conv-1',
+            null,
+        );
+
+        // Existing session is returned untouched, not overwritten.
+        $this->assertSame('domain-uuid-1', $session['domain_uuid']);
+    }
+
+    public function test_requires_domain_and_conversation(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        ReceptionAgentSummonService::ensureInboundSession('', 'conv-1', null);
+    }
+}


### PR DESCRIPTION
Makes an inbound FMC call land on the customer's AI agent instead of voicemail (ystwythv/voxragtm#23). The FMC SIM is a registered extension, so routing is mostly the existing `ai_agents` destination + the extension's no-answer forward — **the real work is giving a *direct inbound* answer the Redis session the qualify/book tools need.** Until now only the `*9` conference summon created that session, so a direct inbound answer couldn't `capture_lead` / `book_appointment`.

## Changes
- **`telnyx-ai-agent-inbound-reception-template.blade.php`** — answers on the agent extension and bridges to the Telnyx assistant, setting the reception context as `X-Voxra-*` INVITE headers (`conversation_id` = the call uuid, `domain_uuid`, caller number). Telnyx surfaces these on `assistant.initialization`.
- **`ReceptionAgentSummonService::ensureInboundSession()`** — bootstraps a minimal session (tenant + conversation + caller); idempotent; no conference/peer.
- **`ReceptionAgentToolController::dynamicVariables()`** — lazily creates that session from the `voxra_*` fields on init, so **the tool controller/service are unchanged** and repeat-caller recognition gets the number for free.
- **`ReceptionAgentController`** — provisions the inbound dialplan on the agent extension (Telnyx-only; upsert by domain+extension), so the existing `ai_agents` destination actually routes an inbound caller to a *reception* agent with tools.
- **`reception-agent:route-extension {domain} {extension} [--disable]`** — points an extension's no-answer/busy/unregistered failover at the domain agent (the "Part 1" glue), or clears it.

## Design notes
- No new Lua/endpoint: reused the fact that Telnyx echoes `X-Voxra-*` SIP headers into `assistant.initialization` (as the `*9` path already relies on). Lower latency than routing a single caller through a conference.
- Fallbacks: no enabled agent → command refuses / voicemail remains; non-Telnyx or no assistant id → dialplan generation is a no-op. Owner DND/forward-all untouched.
- Model/voice per standard: `moonshotai/Kimi-K2.6` + `ultra/alastair` (set at agent provisioning).

## Verification
- **All PHP syntax-checked with `php -l` on the Voxra platform (PHP 8.4).**
- Feature test covers `ensureInboundSession` (create / idempotent / validation) — runs in CI.
- **On-box follow-up (staging, together):** provision a Telnyx reception agent, register an FMC extension, run `reception-agent:route-extension`, call in and don't answer → verify the agent answers, `assistant.initialization` resolves the conversation, and a row lands in `v_reception_leads` / `v_reception_appointments`. Tune ring timeout / codecs. **No FMC-codebase changes.**

Part of ystwythv/voxragtm#23

🤖 Generated with [Claude Code](https://claude.com/claude-code)