### PR TITLE
Contact memory: per end-customer record shared across the team (#89)

### DIFF
--- a/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
+++ b/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
@@ -116,6 +116,8 @@ class ReceptionAgentToolController extends Controller
                 'capture_lead'       => $this->tools->captureLead($session, $args),
                 'check_availability' => $this->tools->checkAvailability($session, $args),
                 'book_appointment'   => $this->tools->bookAppointment($session, $args),
+                'recall_caller'         => $this->tools->recallCaller($session, $args),
+                'remember_about_caller' => $this->tools->rememberAboutCaller($session, $args),
                 'take_notes'         => $this->tools->takeNotes($session, (string) ($args['note'] ?? '')),
                 'email_reminder'     => $this->tools->emailReminder($session, (string) ($args['to'] ?? ''), (string) ($args['subject'] ?? ''), (string) ($args['body'] ?? '')),
                 'complete_and_exit'  => $this->tools->completeAndExit($session, $args['message'] ?? null),

--- a/app/Models/ReceptionContact.php
+++ b/app/Models/ReceptionContact.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Per end-customer memory: a caller's aggregate history within a tenant,
+ * shared across the team. (voxragtm#89)
+ */
+class ReceptionContact extends Model
+{
+    use \App\Models\Traits\TraitUuid;
+
+    protected $table = 'v_reception_contacts';
+
+    public $timestamps = false;
+
+    protected $primaryKey = 'reception_contact_uuid';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'domain_uuid',
+        'phone_number',
+        'name',
+        'first_seen_at',
+        'last_seen_at',
+        'total_calls',
+        'total_bookings',
+        'notes',
+        'preferences',
+        'insert_date',
+        'insert_user',
+        'update_date',
+        'update_user',
+    ];
+
+    protected $casts = [
+        'first_seen_at' => 'datetime',
+        'last_seen_at' => 'datetime',
+        'total_calls' => 'integer',
+        'total_bookings' => 'integer',
+        'preferences' => 'array',
+    ];
+}

--- a/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
@@ -91,6 +91,23 @@ class ReceptionAgentToolDefinitions
                 'required' => ['starts_at', 'service'],
             ],
             [
+                'name' => 'recall_caller',
+                'description' => 'Look up what we already know about the current caller (or a given number) — their name, how many times they have called or booked, and any notes on file — so you can greet returning customers by context. Call this early for a caller you may have dealt with before.',
+                'properties' => [
+                    'number' => ['type' => 'string', 'description' => "The caller's number (optional; defaults to this caller)"],
+                ],
+                'required' => [],
+            ],
+            [
+                'name' => 'remember_about_caller',
+                'description' => 'Save a note about this caller to their record so you and the whole team remember it next time (e.g. "prefers morning appointments", "gate code 1234", "cash only"). Shared across the business.',
+                'properties' => [
+                    'note' => ['type' => 'string', 'description' => 'The note to remember about the caller'],
+                    'number' => ['type' => 'string', 'description' => "The caller's number (optional; defaults to this caller)"],
+                ],
+                'required' => ['note'],
+            ],
+            [
                 'name' => 'take_notes',
                 'description' => 'Record a note from the call; notes are kept and included in the post-call summary.',
                 'properties' => ['note' => ['type' => 'string', 'description' => 'The note text to record']],

--- a/app/Services/ReceptionAgent/ReceptionAgentToolService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolService.php
@@ -4,6 +4,7 @@ namespace App\Services\ReceptionAgent;
 
 use App\Models\Extensions;
 use App\Models\ReceptionAppointment;
+use App\Models\ReceptionContact;
 use App\Models\ReceptionLead;
 use App\Services\FreeswitchEslService;
 use Illuminate\Support\Carbon;
@@ -599,6 +600,7 @@ class ReceptionAgentToolService
         $lead = $convId !== ''
             ? ReceptionLead::where('domain_uuid', $domainUuid)->where('conversation_id', $convId)->first()
             : null;
+        $isNewLead = $lead === null;
 
         if ($lead) {
             $lead->fill($attrs);
@@ -616,6 +618,16 @@ class ReceptionAgentToolService
             ], $attrs));
         }
 
+        // Contact memory: touch the per-customer record (voxragtm#89). Only count
+        // a call on the first capture of this conversation.
+        $contact = $this->touchContact(
+            $domainUuid,
+            $callerNumber,
+            trim((string) ($args['name'] ?? '')) ?: null,
+            $isNewLead,
+            false,
+        );
+
         return [
             'ok'               => true,
             'message'          => $returning
@@ -623,8 +635,146 @@ class ReceptionAgentToolService
                 : 'Got it, thank you.',
             'returning_caller' => $returning,
             'previous_job'     => $previousJob,
+            'times_called'     => $contact?->total_calls,
+            'notes_on_file'    => $contact?->notes ?: null,
             'lead_ref'         => substr((string) $lead->reception_lead_uuid, 0, 8),
         ];
+    }
+
+    // ----- contact memory (voxragtm#89) --------------------------------------
+
+    private function normNumber(?string $number): ?string
+    {
+        $n = trim((string) $number);
+        return $n !== '' ? $n : null;
+    }
+
+    private function resolveContact(string $domainUuid, ?string $number): ?ReceptionContact
+    {
+        $number = $this->normNumber($number);
+        if ($number === null) {
+            return null;
+        }
+        return ReceptionContact::where('domain_uuid', $domainUuid)
+            ->where('phone_number', $number)
+            ->first();
+    }
+
+    /**
+     * Upsert the caller's contact record, bumping counters. Counts are opt-in per
+     * call so we don't over-count repeated tool calls within one conversation.
+     */
+    private function touchContact(
+        string $domainUuid,
+        ?string $number,
+        ?string $name,
+        bool $newConversation,
+        bool $newBooking,
+    ): ?ReceptionContact {
+        $number = $this->normNumber($number);
+        if ($number === null) {
+            return null;
+        }
+        $name = trim((string) $name) ?: null;
+
+        $contact = ReceptionContact::where('domain_uuid', $domainUuid)
+            ->where('phone_number', $number)
+            ->first();
+
+        if (!$contact) {
+            return ReceptionContact::create([
+                'domain_uuid'    => $domainUuid,
+                'phone_number'   => $number,
+                'name'           => $name,
+                'first_seen_at'  => now(),
+                'last_seen_at'   => now(),
+                'total_calls'    => $newConversation ? 1 : 0,
+                'total_bookings' => $newBooking ? 1 : 0,
+                'insert_date'    => now(),
+            ]);
+        }
+
+        if ($name && !$contact->name) {
+            $contact->name = $name;
+        }
+        $contact->last_seen_at = now();
+        if ($newConversation) {
+            $contact->total_calls = (int) $contact->total_calls + 1;
+        }
+        if ($newBooking) {
+            $contact->total_bookings = (int) $contact->total_bookings + 1;
+        }
+        $contact->update_date = now();
+        $contact->save();
+
+        return $contact;
+    }
+
+    /** Return the caller's number from args, else the session (inbound). */
+    private function callerFromArgsOrSession(array $session, array $args): ?string
+    {
+        return $this->normNumber(
+            (string) ($args['number'] ?? $args['caller_number'] ?? $session['caller_number'] ?? ''),
+        );
+    }
+
+    /**
+     * Recall what we know about the current caller (or a given number) so the
+     * agent can greet returning customers by context. (voxragtm#89)
+     */
+    public function recallCaller(array $session, array $args): array
+    {
+        $domainUuid = (string) ($session['domain_uuid'] ?? '');
+        if ($domainUuid === '') {
+            return ['ok' => false, 'message' => 'No active tenant context'];
+        }
+        $number = $this->callerFromArgsOrSession($session, $args);
+        if ($number === null) {
+            return ['ok' => true, 'found' => false, 'message' => "I don't have a number to look up."];
+        }
+
+        $contact = $this->resolveContact($domainUuid, $number);
+        if (!$contact) {
+            return ['ok' => true, 'found' => false, 'message' => 'No history for this caller yet.'];
+        }
+
+        return [
+            'ok'            => true,
+            'found'         => true,
+            'name'          => $contact->name,
+            'times_called'  => (int) $contact->total_calls,
+            'times_booked'  => (int) $contact->total_bookings,
+            'last_seen'     => $contact->last_seen_at ? $contact->last_seen_at->toDateString() : null,
+            'notes'         => $contact->notes,
+        ];
+    }
+
+    /**
+     * Save a note about the caller to their record so the whole team remembers it
+     * next time (e.g. "prefers mornings", "gate code 1234"). (voxragtm#89)
+     */
+    public function rememberAboutCaller(array $session, array $args): array
+    {
+        $domainUuid = (string) ($session['domain_uuid'] ?? '');
+        if ($domainUuid === '') {
+            return ['ok' => false, 'message' => 'No active tenant context'];
+        }
+        $note = trim((string) ($args['note'] ?? ''));
+        if ($note === '') {
+            return ['ok' => false, 'message' => 'What should I remember?'];
+        }
+        $number = $this->callerFromArgsOrSession($session, $args);
+        if ($number === null) {
+            return ['ok' => false, 'message' => "I need the caller's number to save that."];
+        }
+
+        $contact = $this->touchContact($domainUuid, $number, null, false, false);
+        $line = '[' . now()->format('Y-m-d') . '] ' . $note;
+        $contact->notes = $contact->notes ? $contact->notes . "\n" . $line : $line;
+        $contact->update_date = now();
+        $contact->save();
+
+        return ['ok' => true, 'message' => "Saved to their record."];
     }
 
     /**
@@ -739,6 +889,15 @@ class ReceptionAgentToolService
             $lead->update_date = now();
             $lead->save();
         }
+
+        // Contact memory: record the booking against the caller. (voxragtm#89)
+        $this->touchContact(
+            $domainUuid,
+            (trim((string) ($args['customer_number'] ?? '')) ?: $lead?->caller_number) ?: null,
+            (trim((string) ($args['customer_name'] ?? '')) ?: $lead?->name) ?: null,
+            false,
+            true,
+        );
 
         return [
             'ok'              => true,

--- a/database/migrations/2026_07_01_000003_create_v_reception_contacts_table.php
+++ b/database/migrations/2026_07_01_000003_create_v_reception_contacts_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Per end-customer memory (voxragtm#89) — one row per (tenant, phone number),
+ * aggregating a caller's history so the reception agent recognises and greets
+ * returning customers. Tenant-scoped and therefore shared across the team.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('v_reception_contacts')) {
+            Schema::create('v_reception_contacts', function (Blueprint $table) {
+                $table->uuid('reception_contact_uuid')->primary()->default(DB::raw('uuid_generate_v4()'));
+                $table->uuid('domain_uuid');
+                $table->string('phone_number', 64);
+                $table->string('name', 255)->nullable();
+                $table->timestamp('first_seen_at')->nullable();
+                $table->timestamp('last_seen_at')->nullable();
+                $table->integer('total_calls')->default(0);
+                $table->integer('total_bookings')->default(0);
+                $table->text('notes')->nullable();
+                $table->jsonb('preferences')->nullable();
+                $table->timestamp('insert_date')->nullable();
+                $table->uuid('insert_user')->nullable();
+                $table->timestamp('update_date')->nullable();
+                $table->uuid('update_user')->nullable();
+
+                $table->unique(['domain_uuid', 'phone_number']);
+                $table->index('domain_uuid');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('v_reception_contacts');
+    }
+};

--- a/tests/Feature/ReceptionContactMemoryTest.php
+++ b/tests/Feature/ReceptionContactMemoryTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ReceptionContact;
+use App\Services\FreeswitchEslService;
+use App\Services\ReceptionAgent\ReceptionAgentToolService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Per-customer contact memory: aggregate a caller's history across
+ * conversations and let the agent recall / annotate it. (voxragtm#89)
+ */
+class ReceptionContactMemoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $domainUuid;
+    private string $number = '+447700900321';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->domainUuid = (string) Str::uuid();
+    }
+
+    private function service(): ReceptionAgentToolService
+    {
+        return new ReceptionAgentToolService(Mockery::mock(FreeswitchEslService::class));
+    }
+
+    private function session(string $convId): array
+    {
+        return ['domain_uuid' => $this->domainUuid, 'conversation_id' => $convId];
+    }
+
+    public function test_contact_aggregates_calls_and_recognises_returning_callers(): void
+    {
+        $svc = $this->service();
+
+        $first = $svc->captureLead($this->session('conv-1'), [
+            'name' => 'Sam',
+            'caller_number' => $this->number,
+            'job_description' => 'Dripping tap',
+        ]);
+        $this->assertFalse($first['returning_caller']);
+        $this->assertSame(1, $first['times_called']);
+
+        // A later call from the same number (new conversation) is recognised.
+        $second = $svc->captureLead($this->session('conv-2'), [
+            'caller_number' => $this->number,
+            'job_description' => 'Now the boiler',
+        ]);
+        $this->assertTrue($second['returning_caller']);
+        $this->assertSame(2, $second['times_called']);
+
+        $this->assertDatabaseHas('v_reception_contacts', [
+            'domain_uuid' => $this->domainUuid,
+            'phone_number' => $this->number,
+            'name' => 'Sam',
+            'total_calls' => 2,
+        ]);
+    }
+
+    public function test_bookings_count_and_recall_and_remember(): void
+    {
+        $svc = $this->service();
+
+        $svc->captureLead($this->session('conv-1'), [
+            'name' => 'Jo',
+            'caller_number' => $this->number,
+            'job_description' => 'Service',
+        ]);
+
+        $svc->bookAppointment($this->session('conv-1'), [
+            'starts_at' => '2026-07-05 10:00',
+            'service' => 'Boiler service',
+        ]);
+
+        $this->assertDatabaseHas('v_reception_contacts', [
+            'phone_number' => $this->number,
+            'total_bookings' => 1,
+        ]);
+
+        // Save a note, then recall it.
+        $remember = $svc->rememberAboutCaller($this->session('conv-1'), [
+            'number' => $this->number,
+            'note' => 'Prefers mornings',
+        ]);
+        $this->assertTrue($remember['ok']);
+
+        $recall = $svc->recallCaller($this->session('conv-1'), ['number' => $this->number]);
+        $this->assertTrue($recall['found']);
+        $this->assertSame('Jo', $recall['name']);
+        $this->assertSame(1, $recall['times_booked']);
+        $this->assertStringContainsString('Prefers mornings', $recall['notes']);
+    }
+
+    public function test_recall_unknown_caller_is_graceful(): void
+    {
+        $recall = $this->service()->recallCaller($this->session('conv-x'), ['number' => '+447700900999']);
+        $this->assertTrue($recall['ok']);
+        $this->assertFalse($recall['found']);
+        $this->assertSame(0, ReceptionContact::where('domain_uuid', $this->domainUuid)->count());
+    }
+}


### PR DESCRIPTION
**Layer 1 of per-customer shared memory** (ystwythv/voxragtm#88, #89). Promotes repeat-caller recognition into a real tenant-scoped customer record the whole team shares.

## What's added
- **`v_reception_contacts`** — one row per `(domain_uuid, phone)`: name, first/last seen, `total_calls`, `total_bookings`, `notes`, `preferences`. + `ReceptionContact` model.
- **`capture_lead`** now touches the contact (counts a call **once per conversation**) and returns `times_called` + `notes_on_file`; **`book_appointment`** bumps `total_bookings`.
- **New tools:**
  - `recall_caller` — look up the caller's history so the agent greets returning customers by context.
  - `remember_about_caller` — save a note to their record ("prefers mornings", "gate code 1234"), shared across the business.
- Dispatch + provider-neutral tool definitions wired.

## Why tenant-scoped = team-shared
Keyed by `domain_uuid`, so every team member and channel (voice/WhatsApp/web) reads the same memory — the property in the epic.

## Verification
- **All PHP syntax-checked with `php -l` on the Voxra platform (PHP 8.4).**
- Feature test covers cross-conversation aggregation, returning recognition, booking count, recall + remember, and graceful unknown caller — runs in CI.
- New tools activate on the agent's next `reception-agent:provision`.

Part of ystwythv/voxragtm#89 · #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)