### PR TITLE
Business memory + team identity + retrieval (#90, #92, #93)

### DIFF
--- a/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
+++ b/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
@@ -54,9 +54,24 @@ class ReceptionAgentToolController extends Controller
             'payload_keys' => array_keys($payload),
         ]);
 
-        return response()->json([
-            'dynamic_variables' => ['conversation_id' => (string) $conversationId],
-        ]);
+        // Retrieval (voxragtm#93): if we know the tenant + caller, inject a short
+        // brief (returning-caller history + business facts to honour) the
+        // assistant greeting/prompt can use for context.
+        $vars = ['conversation_id' => (string) $conversationId];
+        $domainUuid = (string) ($payload['voxra_domain_uuid'] ?? '');
+        $callerNumber = (string) ($payload['voxra_caller_number'] ?? $payload['telnyx_end_user_target'] ?? '');
+        if ($domainUuid !== '' && $callerNumber !== '') {
+            try {
+                $brief = $this->tools->callerContextBrief($domainUuid, $callerNumber);
+                if ($brief !== '') {
+                    $vars['caller_context'] = $brief;
+                }
+            } catch (Throwable $e) {
+                logger()->warning('reception-agent context brief failed: ' . $e->getMessage());
+            }
+        }
+
+        return response()->json(['dynamic_variables' => $vars]);
     }
 
     public function handle(Request $request): JsonResponse
@@ -118,6 +133,8 @@ class ReceptionAgentToolController extends Controller
                 'book_appointment'   => $this->tools->bookAppointment($session, $args),
                 'recall_caller'         => $this->tools->recallCaller($session, $args),
                 'remember_about_caller' => $this->tools->rememberAboutCaller($session, $args),
+                'remember'              => $this->tools->remember($session, $args),
+                'recall_business'       => $this->tools->recallBusiness($session, $args),
                 'take_notes'         => $this->tools->takeNotes($session, (string) ($args['note'] ?? '')),
                 'email_reminder'     => $this->tools->emailReminder($session, (string) ($args['to'] ?? ''), (string) ($args['subject'] ?? ''), (string) ($args['body'] ?? '')),
                 'complete_and_exit'  => $this->tools->completeAndExit($session, $args['message'] ?? null),

--- a/app/Models/ReceptionMemory.php
+++ b/app/Models/ReceptionMemory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/** A durable business fact/preference for a tenant (voxragtm#90). */
+class ReceptionMemory extends Model
+{
+    use \App\Models\Traits\TraitUuid;
+
+    protected $table = 'v_reception_memory';
+
+    public $timestamps = false;
+
+    protected $primaryKey = 'reception_memory_uuid';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'domain_uuid',
+        'category',
+        'fact',
+        'status',
+        'created_by_number',
+        'created_by_name',
+        'source',
+        'insert_date',
+        'insert_user',
+        'update_date',
+        'update_user',
+    ];
+
+    /** Categories where a change by a non-owner should wait for approval. */
+    public const SENSITIVE = ['pricing', 'policy'];
+}

--- a/app/Models/ReceptionTeamMember.php
+++ b/app/Models/ReceptionTeamMember.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/** Team-member identity for the reception agent (voxragtm#92). */
+class ReceptionTeamMember extends Model
+{
+    use \App\Models\Traits\TraitUuid;
+
+    protected $table = 'v_reception_team_members';
+
+    public $timestamps = false;
+
+    protected $primaryKey = 'reception_team_member_uuid';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'domain_uuid',
+        'phone_number',
+        'name',
+        'role',
+        'insert_date',
+        'insert_user',
+        'update_date',
+        'update_user',
+    ];
+
+    public function isOwner(): bool
+    {
+        return in_array($this->role, ['owner', 'admin'], true);
+    }
+}

--- a/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
@@ -108,6 +108,23 @@ class ReceptionAgentToolDefinitions
                 'required' => ['note'],
             ],
             [
+                'name' => 'remember',
+                'description' => 'Remember a durable fact or preference about how THIS BUSINESS operates, so you and the team use it on future calls (e.g. "we now charge £70 call-out", "don\'t book jobs on Sundays", "always ask if it\'s a boiler under warranty"). For notes about a specific caller use remember_about_caller instead.',
+                'properties' => [
+                    'fact' => ['type' => 'string', 'description' => 'The business fact/preference to remember'],
+                    'category' => ['type' => 'string', 'description' => 'Optional category, e.g. pricing, policy, scheduling, general'],
+                ],
+                'required' => ['fact'],
+            ],
+            [
+                'name' => 'recall_business',
+                'description' => 'Recall what the owner has told you about how the business operates (pricing, policies, preferences), so you can answer accurately. Optionally filter by category.',
+                'properties' => [
+                    'category' => ['type' => 'string', 'description' => 'Optional category to filter by'],
+                ],
+                'required' => [],
+            ],
+            [
                 'name' => 'take_notes',
                 'description' => 'Record a note from the call; notes are kept and included in the post-call summary.',
                 'properties' => ['note' => ['type' => 'string', 'description' => 'The note text to record']],

--- a/app/Services/ReceptionAgent/ReceptionAgentToolService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolService.php
@@ -6,6 +6,8 @@ use App\Models\Extensions;
 use App\Models\ReceptionAppointment;
 use App\Models\ReceptionContact;
 use App\Models\ReceptionLead;
+use App\Models\ReceptionMemory;
+use App\Models\ReceptionTeamMember;
 use App\Services\FreeswitchEslService;
 use Illuminate\Support\Carbon;
 use DateTime;
@@ -775,6 +777,120 @@ class ReceptionAgentToolService
         $contact->save();
 
         return ['ok' => true, 'message' => "Saved to their record."];
+    }
+
+    // ----- team identity (voxragtm#92) ---------------------------------------
+
+    private function resolveTeamMember(string $domainUuid, ?string $number): ?ReceptionTeamMember
+    {
+        $number = $this->normNumber($number);
+        if ($number === null) {
+            return null;
+        }
+        return ReceptionTeamMember::where('domain_uuid', $domainUuid)
+            ->where('phone_number', $number)
+            ->first();
+    }
+
+    // ----- business memory (voxragtm#90) -------------------------------------
+
+    /**
+     * Remember a durable business fact/preference for the tenant, shared across
+     * the team. Provenance is recorded from the speaker; sensitive changes
+     * (pricing/policy) by a non-owner are saved as `pending` for approval.
+     */
+    public function remember(array $session, array $args): array
+    {
+        $domainUuid = (string) ($session['domain_uuid'] ?? '');
+        if ($domainUuid === '') {
+            return ['ok' => false, 'message' => 'No active tenant context'];
+        }
+        $fact = trim((string) ($args['fact'] ?? ''));
+        if ($fact === '') {
+            return ['ok' => false, 'message' => 'What should I remember?'];
+        }
+        $category = strtolower(trim((string) ($args['category'] ?? 'general'))) ?: 'general';
+
+        $speakerNumber = $this->normNumber((string) ($session['caller_number'] ?? ''));
+        $member = $this->resolveTeamMember($domainUuid, $speakerNumber);
+        $isOwner = $member?->isOwner() ?? false;
+
+        $sensitive = in_array($category, ReceptionMemory::SENSITIVE, true);
+        $status = ($sensitive && !$isOwner) ? 'pending' : 'active';
+
+        ReceptionMemory::create([
+            'domain_uuid'       => $domainUuid,
+            'category'          => $category,
+            'fact'              => $fact,
+            'status'            => $status,
+            'created_by_number' => $speakerNumber,
+            'created_by_name'   => $member?->name,
+            'source'            => (string) ($session['source'] ?? '') ?: null,
+            'insert_date'       => now(),
+        ]);
+
+        return [
+            'ok'      => true,
+            'status'  => $status,
+            'message' => $status === 'pending'
+                ? "I've noted that, but a change to {$category} needs the owner to confirm before I use it."
+                : "Got it — I'll remember that.",
+        ];
+    }
+
+    /**
+     * Recall the tenant's active business facts (optionally filtered), so the
+     * agent can answer using what the owner has told it over time.
+     */
+    public function recallBusiness(array $session, array $args): array
+    {
+        $domainUuid = (string) ($session['domain_uuid'] ?? '');
+        if ($domainUuid === '') {
+            return ['ok' => false, 'message' => 'No active tenant context'];
+        }
+        $category = strtolower(trim((string) ($args['category'] ?? '')));
+
+        $facts = ReceptionMemory::where('domain_uuid', $domainUuid)
+            ->where('status', 'active')
+            ->when($category !== '', fn ($q) => $q->where('category', $category))
+            ->orderByDesc('insert_date')
+            ->limit(50)
+            ->get()
+            ->map(fn ($m) => ['category' => $m->category, 'fact' => $m->fact])
+            ->all();
+
+        return ['ok' => true, 'count' => count($facts), 'facts' => $facts];
+    }
+
+    /**
+     * A short natural-language brief about a caller + the business, for the
+     * retrieval layer to inject at conversation start (voxragtm#93).
+     */
+    public function callerContextBrief(string $domainUuid, ?string $callerNumber): string
+    {
+        $parts = [];
+
+        $contact = $this->resolveContact($domainUuid, $callerNumber);
+        if ($contact) {
+            $bits = [];
+            if ($contact->name) $bits[] = "name {$contact->name}";
+            $bits[] = "{$contact->total_calls} previous call(s)";
+            if ((int) $contact->total_bookings > 0) $bits[] = "{$contact->total_bookings} booking(s)";
+            if ($contact->notes) $bits[] = "notes: " . str_replace("\n", "; ", $contact->notes);
+            $parts[] = "Returning caller — " . implode(", ", $bits) . ".";
+        }
+
+        $facts = ReceptionMemory::where('domain_uuid', $domainUuid)
+            ->where('status', 'active')
+            ->orderByDesc('insert_date')
+            ->limit(8)
+            ->pluck('fact')
+            ->all();
+        if ($facts) {
+            $parts[] = "Business notes to honour: " . implode("; ", $facts) . ".";
+        }
+
+        return trim(implode(" ", $parts));
     }
 
     /**

--- a/database/migrations/2026_07_01_000004_create_v_reception_team_members_table.php
+++ b/database/migrations/2026_07_01_000004_create_v_reception_team_members_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Team-member identity (voxragtm#92): maps a phone/WhatsApp number to a tenant
+ * member + role, so the agent knows who it's talking to (owner vs staff) for
+ * personalisation, permissions and provenance on memory writes.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('v_reception_team_members')) {
+            Schema::create('v_reception_team_members', function (Blueprint $table) {
+                $table->uuid('reception_team_member_uuid')->primary()->default(DB::raw('uuid_generate_v4()'));
+                $table->uuid('domain_uuid');
+                $table->string('phone_number', 64);
+                $table->string('name', 255)->nullable();
+                $table->string('role', 20)->default('member'); // owner|admin|member
+                $table->timestamp('insert_date')->nullable();
+                $table->uuid('insert_user')->nullable();
+                $table->timestamp('update_date')->nullable();
+                $table->uuid('update_user')->nullable();
+
+                $table->unique(['domain_uuid', 'phone_number']);
+                $table->index('domain_uuid');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('v_reception_team_members');
+    }
+};

--- a/database/migrations/2026_07_01_000005_create_v_reception_memory_table.php
+++ b/database/migrations/2026_07_01_000005_create_v_reception_memory_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Business memory (voxragtm#90): durable tenant facts/preferences the owner
+ * tells Voxra over time ("we now charge £70 call-out"), shared across the team.
+ * Every fact carries provenance (who said it) and a status so sensitive changes
+ * (pricing/policy) by non-owners can wait for approval.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('v_reception_memory')) {
+            Schema::create('v_reception_memory', function (Blueprint $table) {
+                $table->uuid('reception_memory_uuid')->primary()->default(DB::raw('uuid_generate_v4()'));
+                $table->uuid('domain_uuid');
+                $table->string('category', 40)->default('general'); // general|pricing|policy|scheduling|...
+                $table->text('fact');
+                $table->string('status', 20)->default('active');    // active|pending|archived
+                $table->string('created_by_number', 64)->nullable();
+                $table->string('created_by_name', 255)->nullable();
+                $table->string('source', 20)->nullable();           // voice|whatsapp|web
+                $table->timestamp('insert_date')->nullable();
+                $table->uuid('insert_user')->nullable();
+                $table->timestamp('update_date')->nullable();
+                $table->uuid('update_user')->nullable();
+
+                $table->index(['domain_uuid', 'status']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('v_reception_memory');
+    }
+};

--- a/tests/Feature/ReceptionBusinessMemoryTest.php
+++ b/tests/Feature/ReceptionBusinessMemoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ReceptionTeamMember;
+use App\Services\FreeswitchEslService;
+use App\Services\ReceptionAgent\ReceptionAgentToolService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Business memory (#90), team identity/provenance (#92) and the retrieval brief
+ * (#93).
+ */
+class ReceptionBusinessMemoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $domainUuid;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->domainUuid = (string) Str::uuid();
+    }
+
+    private function service(): ReceptionAgentToolService
+    {
+        return new ReceptionAgentToolService(Mockery::mock(FreeswitchEslService::class));
+    }
+
+    public function test_owner_can_remember_a_fact_and_recall_it(): void
+    {
+        ReceptionTeamMember::create([
+            'domain_uuid' => $this->domainUuid,
+            'phone_number' => '+447700900001',
+            'name' => 'Dave',
+            'role' => 'owner',
+        ]);
+        $session = ['domain_uuid' => $this->domainUuid, 'caller_number' => '+447700900001'];
+
+        $r = $this->service()->remember($session, ['fact' => 'We now charge £70 call-out', 'category' => 'pricing']);
+        $this->assertTrue($r['ok']);
+        $this->assertSame('active', $r['status']);
+
+        $recall = $this->service()->recallBusiness($session, []);
+        $this->assertSame(1, $recall['count']);
+        $this->assertSame('We now charge £70 call-out', $recall['facts'][0]['fact']);
+    }
+
+    public function test_sensitive_fact_from_non_owner_is_pending(): void
+    {
+        // Unknown speaker (not a team member) -> not owner.
+        $session = ['domain_uuid' => $this->domainUuid, 'caller_number' => '+447700900777'];
+
+        $r = $this->service()->remember($session, ['fact' => 'Drop prices 20%', 'category' => 'pricing']);
+        $this->assertTrue($r['ok']);
+        $this->assertSame('pending', $r['status']);
+
+        // Pending facts are not returned by recall (only active).
+        $this->assertSame(0, $this->service()->recallBusiness($session, [])['count']);
+        $this->assertDatabaseHas('v_reception_memory', ['status' => 'pending', 'category' => 'pricing']);
+    }
+
+    public function test_context_brief_combines_caller_history_and_business_facts(): void
+    {
+        $svc = $this->service();
+        $session = ['domain_uuid' => $this->domainUuid, 'conversation_id' => 'c1'];
+
+        $svc->captureLead($session, ['name' => 'Mrs Patel', 'caller_number' => '+447700900123', 'job_description' => 'Boiler']);
+        // General facts are active regardless of speaker, so they appear in the brief.
+        $svc->remember(
+            ['domain_uuid' => $this->domainUuid, 'caller_number' => '+447700900001'],
+            ['fact' => 'Emergencies only after 6pm'],
+        );
+
+        $brief = $svc->callerContextBrief($this->domainUuid, '+447700900123');
+        $this->assertStringContainsString('Mrs Patel', $brief);
+        $this->assertStringContainsString('Emergencies only after 6pm', $brief);
+    }
+}


### PR DESCRIPTION
Layers 2–3 of per-customer shared memory (ystwythv/voxragtm#88). **Stacked on #75 (contact memory)** — base will retarget to `main` once #75 merges.

- **Business memory (#90)** — `v_reception_memory`: durable tenant facts/preferences with **provenance**. Tools `remember` + `recall_business`. Sensitive categories (`pricing`/`policy`) changed by a **non-owner** are saved `pending` for approval (light human-in-the-loop).
- **Team identity (#92)** — `v_reception_team_members` maps a phone/WhatsApp number → member + role, used to attribute writes and gate sensitive changes (owner vs staff).
- **Retrieval (#93)** — `dynamicVariables` injects a `caller_context` brief (returning-caller history + business facts to honour) at conversation start when the tenant + caller are known, so the greeting/prompt has context without an explicit tool call.

## Verification
All PHP **syntax-checked with `php -l` on the Voxra platform (PHP 8.4)**. Feature tests cover remember/recall, the pending guardrail, and the context brief — run in CI. New tools activate on the next `reception-agent:provision`.

Merge order: #75 → this.

Part of ystwythv/voxragtm#90 · #92 · #93 · #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)