### PR TITLE
Episodic memory + GDPR export/erase (#91, #95)

### DIFF
--- a/app/Console/Commands/ReceptionContactData.php
+++ b/app/Console/Commands/ReceptionContactData.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Domain;
+use App\Models\ReceptionAppointment;
+use App\Models\ReceptionContact;
+use App\Models\ReceptionInteraction;
+use App\Models\ReceptionLead;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+/**
+ * GDPR subject access / erasure for a caller's reception memory (voxragtm#95).
+ * Default exports everything held about a number; --delete erases it.
+ *
+ *   php artisan reception:contact-data acme.voxra.uk +447700900123
+ *   php artisan reception:contact-data acme.voxra.uk +447700900123 --delete
+ */
+class ReceptionContactData extends Command
+{
+    protected $signature = 'reception:contact-data
+        {domain : domain_name or domain_uuid}
+        {number : the caller phone number}
+        {--delete : erase all data held about this number}';
+
+    protected $description = 'Export or erase all reception memory held about a caller (GDPR).';
+
+    public function handle(): int
+    {
+        $domainArg = (string) $this->argument('domain');
+        $domain = Str::isUuid($domainArg)
+            ? Domain::where('domain_uuid', $domainArg)->first()
+            : Domain::where('domain_name', $domainArg)->first();
+        if (!$domain) {
+            $this->error("Domain not found: {$domainArg}");
+            return self::FAILURE;
+        }
+
+        $dom = $domain->domain_uuid;
+        $number = trim((string) $this->argument('number'));
+
+        $contact = ReceptionContact::where('domain_uuid', $dom)->where('phone_number', $number)->first();
+        $leads = ReceptionLead::where('domain_uuid', $dom)->where('caller_number', $number)->get();
+        $appointments = ReceptionAppointment::where('domain_uuid', $dom)->where('customer_number', $number)->get();
+        $interactions = $contact
+            ? ReceptionInteraction::where('domain_uuid', $dom)->where('reception_contact_uuid', $contact->reception_contact_uuid)->get()
+            : collect();
+
+        if ($this->option('delete')) {
+            $interactions->each->delete();
+            $appointments->each->delete();
+            $leads->each->delete();
+            $contact?->delete();
+            $this->info(sprintf(
+                'Erased: contact=%d, leads=%d, appointments=%d, interactions=%d for %s',
+                $contact ? 1 : 0,
+                $leads->count(),
+                $appointments->count(),
+                $interactions->count(),
+                $number,
+            ));
+            return self::SUCCESS;
+        }
+
+        $this->line((string) json_encode([
+            'domain_uuid'  => $dom,
+            'number'       => $number,
+            'contact'      => $contact,
+            'leads'        => $leads,
+            'appointments' => $appointments,
+            'interactions' => $interactions,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
+++ b/app/Http/Controllers/Webhooks/ReceptionAgentToolController.php
@@ -135,6 +135,7 @@ class ReceptionAgentToolController extends Controller
                 'remember_about_caller' => $this->tools->rememberAboutCaller($session, $args),
                 'remember'              => $this->tools->remember($session, $args),
                 'recall_business'       => $this->tools->recallBusiness($session, $args),
+                'record_summary'        => $this->tools->recordSummary($session, $args),
                 'take_notes'         => $this->tools->takeNotes($session, (string) ($args['note'] ?? '')),
                 'email_reminder'     => $this->tools->emailReminder($session, (string) ($args['to'] ?? ''), (string) ($args['subject'] ?? ''), (string) ($args['body'] ?? '')),
                 'complete_and_exit'  => $this->tools->completeAndExit($session, $args['message'] ?? null),

--- a/app/Models/ReceptionInteraction.php
+++ b/app/Models/ReceptionInteraction.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/** An episodic interaction summary in the tenant/contact timeline (voxragtm#91). */
+class ReceptionInteraction extends Model
+{
+    use \App\Models\Traits\TraitUuid;
+
+    protected $table = 'v_reception_interactions';
+
+    public $timestamps = false;
+
+    protected $primaryKey = 'reception_interaction_uuid';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'domain_uuid',
+        'reception_contact_uuid',
+        'conversation_id',
+        'channel',
+        'summary',
+        'outcome',
+        'occurred_at',
+        'insert_date',
+        'insert_user',
+    ];
+
+    protected $casts = [
+        'occurred_at' => 'datetime',
+    ];
+
+    public function contact()
+    {
+        return $this->belongsTo(ReceptionContact::class, 'reception_contact_uuid', 'reception_contact_uuid');
+    }
+}

--- a/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolDefinitions.php
@@ -125,6 +125,15 @@ class ReceptionAgentToolDefinitions
                 'required' => [],
             ],
             [
+                'name' => 'record_summary',
+                'description' => 'At the end of the call, record a one or two sentence summary of what happened (and the outcome) to the customer\'s timeline, so next time you can reference it.',
+                'properties' => [
+                    'summary' => ['type' => 'string', 'description' => 'What happened on this call, briefly'],
+                    'outcome' => ['type' => 'string', 'description' => 'Optional: booked | message | transferred | spam | no_action'],
+                ],
+                'required' => ['summary'],
+            ],
+            [
                 'name' => 'take_notes',
                 'description' => 'Record a note from the call; notes are kept and included in the post-call summary.',
                 'properties' => ['note' => ['type' => 'string', 'description' => 'The note text to record']],

--- a/app/Services/ReceptionAgent/ReceptionAgentToolService.php
+++ b/app/Services/ReceptionAgent/ReceptionAgentToolService.php
@@ -5,6 +5,7 @@ namespace App\Services\ReceptionAgent;
 use App\Models\Extensions;
 use App\Models\ReceptionAppointment;
 use App\Models\ReceptionContact;
+use App\Models\ReceptionInteraction;
 use App\Models\ReceptionLead;
 use App\Models\ReceptionMemory;
 use App\Models\ReceptionTeamMember;
@@ -740,6 +741,13 @@ class ReceptionAgentToolService
             return ['ok' => true, 'found' => false, 'message' => 'No history for this caller yet.'];
         }
 
+        $recent = ReceptionInteraction::where('domain_uuid', $domainUuid)
+            ->where('reception_contact_uuid', $contact->reception_contact_uuid)
+            ->orderByDesc('occurred_at')
+            ->limit(3)
+            ->pluck('summary')
+            ->all();
+
         return [
             'ok'            => true,
             'found'         => true,
@@ -748,6 +756,7 @@ class ReceptionAgentToolService
             'times_booked'  => (int) $contact->total_bookings,
             'last_seen'     => $contact->last_seen_at ? $contact->last_seen_at->toDateString() : null,
             'notes'         => $contact->notes,
+            'recent'        => $recent,
         ];
     }
 
@@ -878,6 +887,14 @@ class ReceptionAgentToolService
             if ((int) $contact->total_bookings > 0) $bits[] = "{$contact->total_bookings} booking(s)";
             if ($contact->notes) $bits[] = "notes: " . str_replace("\n", "; ", $contact->notes);
             $parts[] = "Returning caller — " . implode(", ", $bits) . ".";
+
+            $last = ReceptionInteraction::where('domain_uuid', $domainUuid)
+                ->where('reception_contact_uuid', $contact->reception_contact_uuid)
+                ->orderByDesc('occurred_at')
+                ->first();
+            if ($last) {
+                $parts[] = "Last time: {$last->summary}";
+            }
         }
 
         $facts = ReceptionMemory::where('domain_uuid', $domainUuid)
@@ -891,6 +908,42 @@ class ReceptionAgentToolService
         }
 
         return trim(implode(" ", $parts));
+    }
+
+    // ----- episodic memory (voxragtm#91) -------------------------------------
+
+    /**
+     * Record a short summary of this interaction to the tenant/contact timeline,
+     * so future calls can reference what happened last time.
+     */
+    public function recordSummary(array $session, array $args): array
+    {
+        $domainUuid = (string) ($session['domain_uuid'] ?? '');
+        if ($domainUuid === '') {
+            return ['ok' => false, 'message' => 'No active tenant context'];
+        }
+        $summary = trim((string) ($args['summary'] ?? ''));
+        if ($summary === '') {
+            return ['ok' => false, 'message' => 'Nothing to record'];
+        }
+
+        $callerNumber = $this->normNumber((string) ($session['caller_number'] ?? ''));
+        $contact = $callerNumber !== null
+            ? $this->touchContact($domainUuid, $callerNumber, null, false, false)
+            : null;
+
+        ReceptionInteraction::create([
+            'domain_uuid'            => $domainUuid,
+            'reception_contact_uuid' => $contact?->reception_contact_uuid,
+            'conversation_id'        => (string) ($session['conversation_id'] ?? '') ?: null,
+            'channel'                => ((string) ($session['source'] ?? '') === 'whatsapp') ? 'whatsapp' : 'voice',
+            'summary'                => $summary,
+            'outcome'                => trim((string) ($args['outcome'] ?? '')) ?: null,
+            'occurred_at'            => now(),
+            'insert_date'            => now(),
+        ]);
+
+        return ['ok' => true, 'message' => 'Logged.'];
     }
 
     /**

--- a/database/migrations/2026_07_01_000006_create_v_reception_interactions_table.php
+++ b/database/migrations/2026_07_01_000006_create_v_reception_interactions_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Episodic memory (voxragtm#91): a durable timeline of interactions per tenant,
+ * linked to the contact — the summaries behind a customer's history.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('v_reception_interactions')) {
+            Schema::create('v_reception_interactions', function (Blueprint $table) {
+                $table->uuid('reception_interaction_uuid')->primary()->default(DB::raw('uuid_generate_v4()'));
+                $table->uuid('domain_uuid');
+                $table->uuid('reception_contact_uuid')->nullable();
+                $table->string('conversation_id', 255)->nullable();
+                $table->string('channel', 20)->default('voice'); // voice|whatsapp|web
+                $table->text('summary');
+                $table->string('outcome', 40)->nullable();        // booked|message|spam|transferred|...
+                $table->timestamp('occurred_at')->nullable();
+                $table->timestamp('insert_date')->nullable();
+                $table->uuid('insert_user')->nullable();
+
+                $table->index(['domain_uuid', 'reception_contact_uuid']);
+                $table->index(['domain_uuid', 'occurred_at']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('v_reception_interactions');
+    }
+};

--- a/tests/Feature/ReceptionEpisodicMemoryTest.php
+++ b/tests/Feature/ReceptionEpisodicMemoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\FreeswitchEslService;
+use App\Services\ReceptionAgent\ReceptionAgentToolService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+
+/** Episodic memory: record_summary + timeline in recall and the context brief (#91). */
+class ReceptionEpisodicMemoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $domainUuid;
+    private string $number = '+447700900654';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->domainUuid = (string) Str::uuid();
+    }
+
+    private function service(): ReceptionAgentToolService
+    {
+        return new ReceptionAgentToolService(Mockery::mock(FreeswitchEslService::class));
+    }
+
+    public function test_summary_is_recorded_and_surfaced(): void
+    {
+        $svc = $this->service();
+        $session = [
+            'domain_uuid' => $this->domainUuid,
+            'conversation_id' => 'c1',
+            'caller_number' => $this->number,
+        ];
+
+        $svc->captureLead($session, ['name' => 'Ken', 'caller_number' => $this->number, 'job_description' => 'Leak']);
+
+        $rec = $svc->recordSummary($session, ['summary' => 'Booked a boiler service for Friday', 'outcome' => 'booked']);
+        $this->assertTrue($rec['ok']);
+        $this->assertDatabaseHas('v_reception_interactions', [
+            'domain_uuid' => $this->domainUuid,
+            'summary' => 'Booked a boiler service for Friday',
+            'outcome' => 'booked',
+        ]);
+
+        $recall = $svc->recallCaller($session, ['number' => $this->number]);
+        $this->assertContains('Booked a boiler service for Friday', $recall['recent']);
+
+        $brief = $svc->callerContextBrief($this->domainUuid, $this->number);
+        $this->assertStringContainsString('Last time: Booked a boiler service for Friday', $brief);
+    }
+}


### PR DESCRIPTION
Layers 4–5 of per-customer shared memory (ystwythv/voxragtm#88). **Stacked on #76** — base retargets as the stack merges.

- **Episodic (#91)** — `v_reception_interactions`: a durable timeline per tenant/contact. A `record_summary` tool logs what happened each call; `recall_caller` returns recent summaries and the retrieval brief gains a "Last time: …" line.
- **Privacy/GDPR (#95)** — `reception:contact-data {domain} {number}` **exports** everything held about a number (default) or **`--delete`** erases it (contact, leads, appointments, interactions).

All PHP **`php -l`'d on the Voxra platform (PHP 8.4)**; Feature test in CI.

Merge order: #75 → #76 → this.

Part of ystwythv/voxragtm#91 · #95 · #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)