### PR TITLE
API: reception contacts (customer memory) read endpoints (#96)

### DIFF
--- a/app/Data/Api/V1/ReceptionContactData.php
+++ b/app/Data/Api/V1/ReceptionContactData.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Data\Api\V1;
+
+use Spatie\LaravelData\Data;
+
+class ReceptionContactData extends Data
+{
+    public function __construct(
+        public string $reception_contact_uuid,
+        public string $object,
+        public string $domain_uuid,
+        public ?string $phone_number = null,
+        public ?string $name = null,
+        public int $total_calls = 0,
+        public int $total_bookings = 0,
+        public ?string $last_seen_at = null,
+        public ?string $notes = null,
+        /** @var array<int, ReceptionInteractionData> */
+        public ?array $recent = null,
+    ) {}
+}

--- a/app/Data/Api/V1/ReceptionInteractionData.php
+++ b/app/Data/Api/V1/ReceptionInteractionData.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Data\Api\V1;
+
+use Spatie\LaravelData\Data;
+
+class ReceptionInteractionData extends Data
+{
+    public function __construct(
+        public string $reception_interaction_uuid,
+        public string $object,
+        public ?string $channel = null,
+        public ?string $summary = null,
+        public ?string $outcome = null,
+        public ?string $occurred_at = null,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/ReceptionContactController.php
+++ b/app/Http/Controllers/Api/V1/ReceptionContactController.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Data\Api\V1\ReceptionContactData;
+use App\Data\Api\V1\ReceptionInteractionData;
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use App\Models\Domain;
+use App\Models\ReceptionContact;
+use App\Models\ReceptionInteraction;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Spatie\QueryBuilder\QueryBuilder;
+
+/**
+ * Read API over per-customer contact memory (voxragtm#96) — the CRM-style
+ * customer list + timeline for the web/mobile console. Domain-scoped.
+ */
+class ReceptionContactController extends Controller
+{
+    private function requireDomain(Request $request, string $domain_uuid): void
+    {
+        if (! $request->user()) {
+            throw new ApiException(401, 'authentication_error', 'Unauthenticated.', 'unauthenticated');
+        }
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $domain_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid domain UUID.', 'invalid_request', 'domain_uuid');
+        }
+        if (! Domain::query()->where('domain_uuid', $domain_uuid)->exists()) {
+            throw new ApiException(404, 'invalid_request_error', 'Domain not found.', 'resource_missing', 'domain_uuid');
+        }
+    }
+
+    /**
+     * List contacts
+     *
+     * @group Reception
+     * @authenticated
+     */
+    public function index(Request $request, string $domain_uuid)
+    {
+        $this->requireDomain($request, $domain_uuid);
+
+        $limit = max(1, min(100, (int) $request->input('limit', 50)));
+        $startingAfter = (string) $request->input('starting_after', '');
+        if ($startingAfter !== '' && ! preg_match('/^[0-9a-fA-F-]{36}$/', $startingAfter)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid starting_after UUID.', 'invalid_request', 'starting_after');
+        }
+
+        $query = QueryBuilder::for(ReceptionContact::class)
+            ->where('domain_uuid', $domain_uuid)
+            ->defaultSort('reception_contact_uuid')
+            ->reorder('reception_contact_uuid')
+            ->limit($limit + 1);
+
+        if ($startingAfter !== '') {
+            $query->where('reception_contact_uuid', '>', $startingAfter);
+        }
+
+        $rows = $query->get();
+        $hasMore = $rows->count() > $limit;
+        $rows = $rows->take($limit);
+
+        $data = $rows->map(fn ($c) => $this->toData($c));
+
+        return response()->json([
+            'object'   => 'list',
+            'url'      => "/api/v1/domains/{$domain_uuid}/reception/contacts",
+            'has_more' => $hasMore,
+            'data'     => $data,
+        ], 200);
+    }
+
+    /**
+     * Retrieve a contact with its recent interaction timeline
+     *
+     * @group Reception
+     * @authenticated
+     */
+    public function show(Request $request, string $domain_uuid, string $contact_uuid)
+    {
+        $this->requireDomain($request, $domain_uuid);
+        if (! preg_match('/^[0-9a-fA-F-]{36}$/', $contact_uuid)) {
+            throw new ApiException(400, 'invalid_request_error', 'Invalid contact UUID.', 'invalid_request', 'contact_uuid');
+        }
+
+        $contact = ReceptionContact::where('domain_uuid', $domain_uuid)
+            ->where('reception_contact_uuid', $contact_uuid)
+            ->first();
+        if (! $contact) {
+            throw new ApiException(404, 'invalid_request_error', 'Contact not found.', 'resource_missing', 'contact_uuid');
+        }
+
+        $interactions = ReceptionInteraction::where('domain_uuid', $domain_uuid)
+            ->where('reception_contact_uuid', $contact_uuid)
+            ->orderByDesc('occurred_at')
+            ->limit(50)
+            ->get()
+            ->map(fn ($i) => new ReceptionInteractionData(
+                reception_interaction_uuid: (string) $i->reception_interaction_uuid,
+                object: 'reception_interaction',
+                channel: $i->channel,
+                summary: $i->summary,
+                outcome: $i->outcome,
+                occurred_at: $i->occurred_at ? Carbon::parse($i->occurred_at)->toIso8601String() : null,
+            ))
+            ->all();
+
+        return response()->json($this->toData($contact, $interactions), 200);
+    }
+
+    private function toData(ReceptionContact $c, ?array $recent = null): ReceptionContactData
+    {
+        return new ReceptionContactData(
+            reception_contact_uuid: (string) $c->reception_contact_uuid,
+            object: 'reception_contact',
+            domain_uuid: (string) $c->domain_uuid,
+            phone_number: $c->phone_number,
+            name: $c->name,
+            total_calls: (int) $c->total_calls,
+            total_bookings: (int) $c->total_bookings,
+            last_seen_at: $c->last_seen_at ? Carbon::parse($c->last_seen_at)->toIso8601String() : null,
+            notes: $c->notes,
+            recent: $recent,
+        );
+    }
+}

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -162,6 +162,17 @@ Route::middleware(['auth:sanctum', 'api.token.auth', 'throttle:api'])->group(fun
 
     /*
     |--------------------------------------------------------------------------
+    | Reception contacts — per-customer memory (read-only)
+    |--------------------------------------------------------------------------
+    */
+    Route::get('/domains/{domain_uuid}/reception/contacts', [\App\Http\Controllers\Api\V1\ReceptionContactController::class, 'index'])
+        ->middleware('user.authorize:ai_agent_view')->name('api.v1.reception.contacts.index');
+
+    Route::get('/domains/{domain_uuid}/reception/contacts/{contact_uuid}', [\App\Http\Controllers\Api\V1\ReceptionContactController::class, 'show'])
+        ->middleware('user.authorize:ai_agent_view')->name('api.v1.reception.contacts.show');
+
+    /*
+    |--------------------------------------------------------------------------
     | CDR (Call Detail Records) — domain-scoped, read-only
     |--------------------------------------------------------------------------
     | All routes enforce tenant-vs-global token scope via `cdr.scope`. Stats

--- a/tests/Feature/Api/V1/Reception/ReceptionContactsRouteProtectionTest.php
+++ b/tests/Feature/Api/V1/Reception/ReceptionContactsRouteProtectionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature\Api\V1\Reception;
+
+use Tests\TestCase;
+
+/** Auth-chain smoke test for the reception contacts read API (voxragtm#96). */
+class ReceptionContactsRouteProtectionTest extends TestCase
+{
+    private const DOMAIN = '00000000-0000-0000-0000-000000000001';
+
+    public function test_contacts_index_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/reception/contacts')
+            ->assertStatus(401);
+    }
+
+    public function test_contact_show_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/domains/' . self::DOMAIN . '/reception/contacts/00000000-0000-0000-0000-000000000002')
+            ->assertStatus(401);
+    }
+}


### PR DESCRIPTION
The read API behind the console customer view (ystwythv/voxragtm#96). **Stacked on #77.**

- `GET /api/v1/domains/{domain_uuid}/reception/contacts` — cursor-paginated customer list.
- `GET /api/v1/domains/{domain_uuid}/reception/contacts/{contact_uuid}` — a contact + its recent interaction timeline.

`ReceptionContactData` / `ReceptionInteractionData` resources; mirrors the existing V1 patterns (ApiException, QueryBuilder, cursor); reuses `ai_agent_view`. Route-protection test; **`php -l`'d on the platform (PHP 8.4)**.

The voxraweb console UI consumes this (separate PR).

Merge order: #75 → #76 → #77 → this.

Part of ystwythv/voxragtm#96 · #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)