### PR TITLE
Default reception-agent voice to UK (Alistair, Telnyx Ultra)

### DIFF
--- a/app/Services/TelnyxConvaiService.php
+++ b/app/Services/TelnyxConvaiService.php
@@ -17,6 +17,13 @@ use Illuminate\Http\Client\ConnectionException;
  */
 class TelnyxConvaiService
 {
+    /**
+     * Default assistant voice when none is specified: "Alistair — Composed
+     * Consultant", a British male Telnyx Ultra voice (voxra voice standard).
+     * Without this, Telnyx assigns a US default (Katie), which is wrong for UK.
+     */
+    public const DEFAULT_VOICE = 'Telnyx.Ultra.c8f7835e-28a3-4f0c-80d7-c1302ac62aae';
+
     private string $apiKey;
     private string $baseUrl;
     private int $timeout;
@@ -43,7 +50,7 @@ class TelnyxConvaiService
             'instructions' => $instructions ?? '',
             'greeting'     => $greeting ?? '',
             'model'        => $model,
-            'voice_settings' => $voice ? ['voice' => $voice] : null,
+            'voice_settings' => ['voice' => $voice ?: self::DEFAULT_VOICE],
             'transcription'  => ['language' => $language],
         ], fn ($v) => $v !== null);
 


### PR DESCRIPTION
Omitting --voice left voice_settings null, so Telnyx assigned a US default (Katie). Default to Alistair (British male, Ultra) so provisioned agents are UK by default. Live assistants already switched via API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)