### PR TITLE
provision-tenant: pass feature_code (*9)

### DIFF
--- a/app/Http/Controllers/Internal/ProvisionTenantController.php
+++ b/app/Http/Controllers/Internal/ProvisionTenantController.php
@@ -55,6 +55,7 @@ class ProvisionTenantController extends Controller
                 'provider'        => 'telnyx',
                 'model'           => 'moonshotai/Kimi-K2.6',
                 'telnyx_voice_id' => self::UK_VOICE,
+                'feature_code'    => '*9',
                 'agent_enabled'   => 'true',
             ]
         );


### PR DESCRIPTION
upsertReceptionAgent requires feature_code; default *9 (was 500). 🤖 Generated with [Claude Code](https://claude.com/claude-code)