### PR TITLE
Auto-order + route a DID on activation (#23)

### DIFF
--- a/app/Http/Controllers/Internal/ProvisionTenantController.php
+++ b/app/Http/Controllers/Internal/ProvisionTenantController.php
@@ -60,6 +60,16 @@ class ProvisionTenantController extends Controller
             ]
         );
 
+        // Auto-order + route a DID (voxragtm#23) — gated + spend-capped; returns
+        // null unless VOXRA_PROVISION_ORDER_NUMBER is enabled. Best-effort: a
+        // number failure must not fail provisioning (domain + agent are done).
+        $number = null;
+        try {
+            $number = app(\App\Services\ProvisionNumberService::class)->orderAndRoute($domain, $agent);
+        } catch (\Throwable $e) {
+            logger('Voxra auto-number failed for ' . $domain->domain_name . ': ' . $e->getMessage());
+        }
+
         return response()->json([
             'ok'                  => true,
             'domain_uuid'         => $domain->domain_uuid,
@@ -67,7 +77,7 @@ class ProvisionTenantController extends Controller
             'agent_extension'     => $agent->agent_extension,
             'feature_code'        => $agent->feature_code,
             'telnyx_assistant_id' => $agent->telnyx_assistant_id,
-            'number'              => null, // number ordering is a gated follow-up (paid)
+            'number'              => $number,
         ]);
     }
 

--- a/app/Services/ProvisionNumberService.php
+++ b/app/Services/ProvisionNumberService.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AiAgent;
+use App\Models\Destinations;
+use App\Models\Domain;
+use Illuminate\Support\Str;
+
+/**
+ * Auto-order a Telnyx DID for a tenant on activation and route it to their
+ * reception agent (voxragtm#23, completes #42).
+ *
+ * GATED + SPEND-CAPPED: does nothing unless `services.voxra.provision_order_number`
+ * is true AND a `number_connection_id` is set. `createOrder` is the only paid
+ * call; it's skipped when disabled. Inbound routing: the DID lands (source-IP
+ * gated, no auth) in FreeSWITCH's `public` context via the voxra-pbx-inbound
+ * FQDN connection (→ sip-in.voxra.uk SRV → lon1/eu1:5080), and the v_destinations
+ * row we create routes destination_number → the agent's extension.
+ */
+class ProvisionNumberService
+{
+    /** Order a UK number within the cap and route it to the agent. Returns the
+     *  E.164 number, or null when disabled / nothing suitable. */
+    public function orderAndRoute(Domain $domain, AiAgent $agent): ?string
+    {
+        if (! config('services.voxra.provision_order_number')) {
+            return null;
+        }
+        $connectionId = (string) config('services.voxra.number_connection_id', '');
+        if ($connectionId === '') {
+            logger('Voxra auto-number skipped: services.voxra.number_connection_id not set');
+            return null;
+        }
+
+        $svc = app(TelnyxNumberService::class);
+        $cap = (float) config('services.voxra.number_max_monthly_cost', 5.0);
+
+        $candidates = $svc->searchAvailable([
+            'country'  => config('services.voxra.number_country', 'GB'),
+            'type'     => config('services.voxra.number_type', 'local'),
+            'features' => ['voice', 'sms'],
+            'limit'    => 10,
+        ]);
+
+        $pick = null;
+        foreach ($candidates as $c) {
+            $cost = $c['monthly_cost'] ?? null;
+            if ($cost === null || (float) $cost <= $cap) {
+                $pick = $c;
+                break;
+            }
+        }
+        if (! $pick) {
+            logger('Voxra auto-number skipped: no candidate within monthly cap ' . $cap);
+            return null;
+        }
+
+        $number = $pick['phone_number'];
+        $messagingProfileId = (string) config('services.voxra.number_messaging_profile_id', '') ?: null;
+
+        $order = $svc->createOrder([$number], $connectionId, $messagingProfileId);
+
+        // Orders settle asynchronously — poll briefly (routing works regardless).
+        if (! empty($order['id'])) {
+            for ($i = 0; $i < 5; $i++) {
+                $state = $svc->getOrder($order['id']);
+                if (($state['status'] ?? '') === 'success') {
+                    break;
+                }
+                usleep(1_500_000);
+            }
+        }
+
+        $this->routeDidToAgent($domain, $agent, $number);
+
+        return $number;
+    }
+
+    /** Create the inbound v_destinations row routing a DID to the reception
+     *  agent's extension, and build its public-context dialplan. */
+    public function routeDidToAgent(Domain $domain, AiAgent $agent, string $did): void
+    {
+        $action = buildDestinationAction(
+            ['type' => 'ai_agents', 'extension' => $agent->agent_extension],
+            $domain->domain_name,
+        );
+
+        $dest = new Destinations();
+        $dest->fill([
+            'destination_uuid'        => (string) Str::uuid(),
+            'domain_uuid'             => $domain->domain_uuid,
+            'dialplan_uuid'           => (string) Str::uuid(),
+            'destination_type'        => 'inbound',
+            'destination_number'      => $did, // +E.164 (connection dnis_number_format = +e164)
+            'destination_actions'     => json_encode([$action]),
+            'destination_enabled'     => true,
+            'destination_context'     => 'public',
+            'destination_description' => 'Voxra reception (auto-provisioned)',
+        ]);
+        $dest->save();
+
+        dispatch(new \App\Jobs\BuildDialplanForPhoneNumber($dest->destination_uuid, $domain->domain_name));
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -123,6 +123,17 @@ return [
     'voxra' => [
         'app_url' => env('VOXRA_APP_URL', ''),                     // e.g. https://voxraweb.vercel.app
         'agent_tool_secret' => env('VOXRA_AGENT_TOOL_SECRET', ''), // shared secret sent on data-tool calls
+
+        // Auto-order a Telnyx DID on activation + route it to the reception agent
+        // (voxragtm#23). OFF by default — createOrder spends money. Enable by
+        // setting VOXRA_PROVISION_ORDER_NUMBER=true once tested. The connection
+        // id defaults to the voxra-pbx-inbound FQDN connection (→ sip-in.voxra.uk).
+        'provision_order_number' => env('VOXRA_PROVISION_ORDER_NUMBER', false),
+        'number_connection_id' => env('VOXRA_NUMBER_CONNECTION_ID', '2994981238638380563'),
+        'number_messaging_profile_id' => env('VOXRA_NUMBER_MESSAGING_PROFILE_ID', ''),
+        'number_country' => env('VOXRA_NUMBER_COUNTRY', 'GB'),
+        'number_type' => env('VOXRA_NUMBER_TYPE', 'local'),
+        'number_max_monthly_cost' => (float) env('VOXRA_NUMBER_MAX_MONTHLY_COST', 5.0),
     ],
 
     'keygen' => [


### PR DESCRIPTION
Completes full provisioning: on activation, optionally order a UK Telnyx number (spend-capped) on the voxra-pbx-inbound connection and route the DID → reception agent via a v_destinations row + public dialplan. **Gated OFF** (VOXRA_PROVISION_ORDER_NUMBER); createOrder is the only paid call. Lint clean on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)