### PR TITLE
Gate number order on approved regulatory requirement group (#23)

### DIFF
--- a/app/Http/Controllers/Internal/ProvisionTenantController.php
+++ b/app/Http/Controllers/Internal/ProvisionTenantController.php
@@ -28,8 +28,9 @@ class ProvisionTenantController extends Controller
     public function provision(Request $request): JsonResponse
     {
         $data = $request->validate([
-            'tenant_id'     => 'required|string|max:64',
-            'business_name' => 'required|string|max:120',
+            'tenant_id'            => 'required|string|max:64',
+            'business_name'        => 'required|string|max:120',
+            'requirement_group_id' => 'nullable|string|max:64',
         ]);
 
         $tenantId = $data['tenant_id'];
@@ -65,7 +66,8 @@ class ProvisionTenantController extends Controller
         // number failure must not fail provisioning (domain + agent are done).
         $number = null;
         try {
-            $number = app(\App\Services\ProvisionNumberService::class)->orderAndRoute($domain, $agent);
+            $number = app(\App\Services\ProvisionNumberService::class)
+                ->orderAndRoute($domain, $agent, $data['requirement_group_id'] ?? null);
         } catch (\Throwable $e) {
             logger('Voxra auto-number failed for ' . $domain->domain_name . ': ' . $e->getMessage());
         }

--- a/app/Services/ProvisionNumberService.php
+++ b/app/Services/ProvisionNumberService.php
@@ -22,7 +22,7 @@ class ProvisionNumberService
 {
     /** Order a UK number within the cap and route it to the agent. Returns the
      *  E.164 number, or null when disabled / nothing suitable. */
-    public function orderAndRoute(Domain $domain, AiAgent $agent): ?string
+    public function orderAndRoute(Domain $domain, AiAgent $agent, ?string $requirementGroupId = null): ?string
     {
         if (! config('services.voxra.provision_order_number')) {
             return null;
@@ -30,6 +30,12 @@ class ProvisionNumberService
         $connectionId = (string) config('services.voxra.number_connection_id', '');
         if ($connectionId === '') {
             logger('Voxra auto-number skipped: services.voxra.number_connection_id not set');
+            return null;
+        }
+        // Regulatory gate: UK numbers require an APPROVED requirement group
+        // (proof of address + ID). voxraweb passes it only when approved.
+        if (! $requirementGroupId) {
+            logger('Voxra auto-number skipped: no approved regulatory requirement group for ' . $domain->domain_name);
             return null;
         }
 
@@ -59,7 +65,7 @@ class ProvisionNumberService
         $number = $pick['phone_number'];
         $messagingProfileId = (string) config('services.voxra.number_messaging_profile_id', '') ?: null;
 
-        $order = $svc->createOrder([$number], $connectionId, $messagingProfileId);
+        $order = $svc->createOrder([$number], $connectionId, $messagingProfileId, $requirementGroupId);
 
         // Orders settle asynchronously — poll briefly (routing works regardless).
         if (! empty($order['id'])) {

--- a/app/Services/TelnyxNumberService.php
+++ b/app/Services/TelnyxNumberService.php
@@ -81,14 +81,17 @@ class TelnyxNumberService
      * @param  array<int,string>  $phoneNumbers  E.164 numbers, e.g. ['+442071234567']
      * @return array{id:?string,status:?string,phone_numbers:array<int,mixed>}
      */
-    public function createOrder(array $phoneNumbers, ?string $connectionId = null, ?string $messagingProfileId = null): array
+    public function createOrder(array $phoneNumbers, ?string $connectionId = null, ?string $messagingProfileId = null, ?string $requirementGroupId = null): array
     {
         if ($phoneNumbers === []) {
             throw new RuntimeException('createOrder requires at least one phone number.');
         }
 
         $body = array_filter([
-            'phone_numbers'        => array_map(fn (string $n) => ['phone_number' => $n], array_values($phoneNumbers)),
+            'phone_numbers'        => array_map(fn (string $n) => array_filter([
+                'phone_number'         => $n,
+                'requirement_group_id' => $requirementGroupId,
+            ], fn ($v) => $v !== null), array_values($phoneNumbers)),
             'connection_id'        => $connectionId,
             'messaging_profile_id' => $messagingProfileId,
         ], fn ($v) => $v !== null);


### PR DESCRIPTION
createOrder takes a requirement_group_id (per number); orderAndRoute requires it (no approved regulatory group ⇒ no number); the provision endpoint threads it from voxraweb. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)