### PR TITLE
Link IP-authorized outbound CDRs to extensions via SIP From user

### DIFF
--- a/app/Console/Daemons/cdr_import.php
+++ b/app/Console/Daemons/cdr_import.php
@@ -979,6 +979,25 @@ if (!class_exists('cdr_import')) {
 								$this->array[$key]['extension_uuid'] = $extension_uuid;
 								unset($parameters);
 							}
+							//outbound/local calls that arrive IP-authorized (e.g. FMC/SBC trunks) never load
+							//the directory user, so extension_uuid is not set on the channel; match the
+							//SIP From user to an extension in the same domain instead
+							if (empty($this->array[$key]['extension_uuid']) && isset($domain_uuid) && isset($xml->variables->sip_from_user) && isset($xml->variables->call_direction)) {
+								$call_direction = urldecode($xml->variables->call_direction);
+								if ($call_direction == 'outbound' || $call_direction == 'local') {
+									$sql = "select extension_uuid from v_extensions ";
+									$sql .= "where domain_uuid = :domain_uuid ";
+									$sql .= "and (extension = :sip_from_user or number_alias = :sip_from_user) ";
+									$parameters['domain_uuid'] = $domain_uuid;
+									$parameters['sip_from_user'] = urldecode($xml->variables->sip_from_user);
+									$database = new database;
+									$extension_uuid = $database->select($sql, $parameters, 'column');
+									if (!empty($extension_uuid)) {
+										$this->array[$key]['extension_uuid'] = $extension_uuid;
+									}
+									unset($parameters);
+								}
+							}
 						}
 
 					//store xml cdr on the file system as a file


### PR DESCRIPTION
## Problem

Recorded calls for `810@iqmobile.uk` only showed inbound calls in Call History. Outbound calls from FMC-backed extensions **are** recorded, but the CDR rows have `extension_uuid = NULL` and `caller_id_number` rewritten to the outbound CLI (e.g. `447970030010`), so the extension entity filter in `CdrDataService` never matches them.

Root cause: outbound calls from the FMC SBC (`iq-fmc-lon2-sip2`, 172.236.8.104) are IP-authorized rather than digest-authenticated, so FreeSWITCH never loads the directory user and the `extension_uuid` channel variable is absent from the CDR XML. The importer's existing fallbacks (`dialed_user`, `referred_by_user`, `last_sent_callee_id_number`) only cover inbound/transfer cases.

## Fix

Add a final fallback in `cdr_import.php` (shared by `fs_cdr_service.php`): for `outbound`/`local` legs with no `extension_uuid`, match `sip_from_user` against `extension`/`number_alias` in the same domain. Verified against a live CDR (`b50b24b1-fc3a-4b1e-a3f0-8fb7f596f5bb`) where `sip_from_user=810`, `sip_from_host=iqmobile.uk`, `call_direction=outbound`.

No effect on inbound legs (guarded by `call_direction`) or on calls that already carry `extension_uuid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DK59AfYj16fpWXzwHkQBx