### PR TITLE
Add per-domain call recording webhooks

### DIFF
--- a/app/Console/Commands/DispatchRecordingWebhooks.php
+++ b/app/Console/Commands/DispatchRecordingWebhooks.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\CDR;
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+use App\Jobs\SendRecordingWebhook;
+use App\Models\RecordingWebhookDelivery;
+use App\Services\RecordingWebhookConfigService;
+
+class DispatchRecordingWebhooks extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'webhooks:dispatch-recordings
+        {--lookback-hours=24 : Only consider CDRs that started within this window}
+        {--retry-failed : Re-dispatch deliveries that previously failed}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Queue call recording webhooks for domains that have them enabled';
+
+    public function handle(RecordingWebhookConfigService $configService)
+    {
+        $configs = $configService->getEnabledDomainConfigs();
+
+        if (empty($configs)) {
+            return Command::SUCCESS;
+        }
+
+        if ($this->option('retry-failed')) {
+            $this->retryFailed(array_keys($configs));
+        }
+
+        $lookback = now()->subHours(max(1, (int) $this->option('lookback-hours')));
+        $dispatched = 0;
+
+        foreach ($configs as $domainUuid => $config) {
+            $cdrs = CDR::query()
+                ->where('domain_uuid', $domainUuid)
+                ->whereNotNull('record_name')
+                ->where('record_name', '!=', '')
+                ->whereIn('direction', $config['directions'])
+                ->where('start_stamp', '>=', $lookback)
+                ->whereNotNull('end_stamp')
+                ->whereNotExists(function ($query) {
+                    $query->selectRaw('1')
+                        ->from('recording_webhook_deliveries')
+                        ->whereColumn('recording_webhook_deliveries.domain_uuid', 'v_xml_cdr.domain_uuid')
+                        ->whereColumn('recording_webhook_deliveries.record_name', 'v_xml_cdr.record_name');
+                })
+                ->orderBy('start_stamp')
+                ->get([
+                    'xml_cdr_uuid',
+                    'domain_uuid',
+                    'record_name',
+                    'direction',
+                    'billsec',
+                    'start_stamp',
+                ]);
+
+            // Ring group / transfer legs share one recording file — send one
+            // webhook per file, using the leg that carried the conversation
+            $primaryLegs = $cdrs->groupBy('record_name')->map(function ($legs) {
+                return $legs->sortByDesc('billsec')->first();
+            });
+
+            foreach ($primaryLegs as $cdr) {
+                // insertOrIgnore + unique(domain_uuid, record_name) is the atomic
+                // claim: whichever cluster node inserts the row sends the webhook
+                $inserted = RecordingWebhookDelivery::insertOrIgnore([
+                    'uuid' => (string) Str::uuid(),
+                    'domain_uuid' => $cdr->domain_uuid,
+                    'xml_cdr_uuid' => $cdr->xml_cdr_uuid,
+                    'record_name' => $cdr->record_name,
+                    'url' => $config['url'],
+                    'status' => RecordingWebhookDelivery::STATUS_PENDING,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+
+                if ($inserted === 1) {
+                    $delivery = RecordingWebhookDelivery::where('domain_uuid', $cdr->domain_uuid)
+                        ->where('record_name', $cdr->record_name)
+                        ->first();
+
+                    SendRecordingWebhook::dispatch($delivery->uuid);
+                    $dispatched++;
+                }
+            }
+        }
+
+        if ($dispatched > 0) {
+            $this->info("Dispatched {$dispatched} recording webhook(s)");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function retryFailed(array $domainUuids): void
+    {
+        $failed = RecordingWebhookDelivery::whereIn('domain_uuid', $domainUuids)
+            ->where('status', RecordingWebhookDelivery::STATUS_FAILED)
+            ->get();
+
+        foreach ($failed as $delivery) {
+            $delivery->update([
+                'status' => RecordingWebhookDelivery::STATUS_PENDING,
+                'last_error' => null,
+            ]);
+
+            SendRecordingWebhook::dispatch($delivery->uuid);
+            $this->info("Retrying failed delivery {$delivery->uuid}");
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -95,6 +95,11 @@ class Kernel extends ConsoleKernel
             $schedule->job(new ProcessWakeupCalls())->everyMinute();
         }
 
+        // Dispatch call recording webhooks for enabled domains
+        if (isset($jobSettings['recording_webhooks']) && $jobSettings['recording_webhooks'] === "true") {
+            $schedule->command('webhooks:dispatch-recordings')->everyMinute();
+        }
+
         if (isset($jobSettings['delete_old_faxes']) && $jobSettings['delete_old_faxes'] === "true") {
             // Retrieve the days to keep faxes from settings or default to 90 days.
             $daysKeepFax = $jobSettings['days_keep_fax'] ?? 90;

--- a/app/Jobs/SendRecordingWebhook.php
+++ b/app/Jobs/SendRecordingWebhook.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\CDR;
+use Illuminate\Bus\Queueable;
+use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use App\Models\RecordingWebhookDelivery;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Services\CallRecordingUrlService;
+use Illuminate\Foundation\Bus\Dispatchable;
+use App\Services\RecordingWebhookConfigService;
+
+class SendRecordingWebhook implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $tries = 5;
+
+    public $backoff = [60, 300, 900, 1800];
+
+    public function __construct(
+        public string $deliveryUuid
+    ) {
+    }
+
+    public function handle(
+        RecordingWebhookConfigService $configService,
+        CallRecordingUrlService $urlService
+    ) {
+        $delivery = RecordingWebhookDelivery::find($this->deliveryUuid);
+
+        if (!$delivery || $delivery->status === RecordingWebhookDelivery::STATUS_SENT) {
+            return;
+        }
+
+        $config = $configService->getSettingsForDomain($delivery->domain_uuid);
+
+        if (!$config) {
+            $delivery->update([
+                'status' => RecordingWebhookDelivery::STATUS_SKIPPED,
+                'last_error' => 'Webhook disabled for domain at send time',
+            ]);
+            return;
+        }
+
+        $cdr = CDR::query()
+            ->with([
+                'extension:extension_uuid,extension,effective_caller_id_name',
+                'domain:domain_uuid,domain_name',
+            ])
+            ->where('xml_cdr_uuid', $delivery->xml_cdr_uuid)
+            ->first();
+
+        if (!$cdr) {
+            $delivery->update([
+                'status' => RecordingWebhookDelivery::STATUS_FAILED,
+                'last_error' => 'CDR no longer exists',
+            ]);
+            return;
+        }
+
+        $delivery->increment('attempts');
+
+        $urls = $urlService->urlsForCdr($cdr->xml_cdr_uuid, $config['url_ttl']);
+
+        if (empty($urls['audio_url'])) {
+            throw new \RuntimeException('No recording URL available for CDR ' . $cdr->xml_cdr_uuid);
+        }
+
+        $payload = [
+            'event' => 'recording.available',
+            'delivery_uuid' => $delivery->uuid,
+            'cdr_uuid' => $cdr->xml_cdr_uuid,
+            'domain' => $cdr->domain->domain_name ?? null,
+            'direction' => $cdr->direction,
+            'extension' => $cdr->extension->extension ?? null,
+            'extension_name' => $cdr->extension->effective_caller_id_name ?? null,
+            'caller_id_name' => $cdr->caller_id_name,
+            'caller_id_number' => $cdr->caller_id_number,
+            'caller_destination' => $cdr->caller_destination,
+            'destination_number' => $cdr->destination_number,
+            'start' => $cdr->start_stamp ? Carbon::parse($cdr->start_stamp)->toIso8601String() : null,
+            'end' => $cdr->end_stamp ? Carbon::parse($cdr->end_stamp)->toIso8601String() : null,
+            'duration' => (int) $cdr->duration,
+            'billsec' => (int) $cdr->billsec,
+            'hangup_cause' => $cdr->hangup_cause,
+            'recording' => [
+                'url' => $urls['audio_url'],
+                'download_url' => $urls['download_url'],
+                'filename' => $urls['filename'],
+                'expires_at' => now()->addSeconds($config['url_ttl'])->toIso8601String(),
+                'format' => strtolower(pathinfo($urls['filename'] ?? '', PATHINFO_EXTENSION)) ?: null,
+            ],
+        ];
+
+        $body = json_encode($payload, JSON_UNESCAPED_SLASHES);
+        $timestamp = time();
+        $signature = hash_hmac('sha256', $timestamp . '.' . $body, $config['secret']);
+
+        $response = Http::withHeaders([
+            'Content-Type' => 'application/json',
+            'X-Voxra-Event' => 'recording.available',
+            'X-Voxra-Delivery' => $delivery->uuid,
+            'X-Voxra-Timestamp' => (string) $timestamp,
+            'X-Voxra-Signature' => 't=' . $timestamp . ',v0=' . $signature,
+        ])
+            ->timeout(30)
+            ->withBody($body, 'application/json')
+            ->post($config['url']);
+
+        if (!$response->successful()) {
+            $delivery->update([
+                'last_error' => 'HTTP ' . $response->status() . ': ' . Str::limit($response->body(), 500),
+            ]);
+            throw new \RuntimeException(
+                'Webhook endpoint returned HTTP ' . $response->status() . ' for delivery ' . $delivery->uuid
+            );
+        }
+
+        $delivery->update([
+            'status' => RecordingWebhookDelivery::STATUS_SENT,
+            'sent_at' => now(),
+            'last_error' => null,
+        ]);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        RecordingWebhookDelivery::where('uuid', $this->deliveryUuid)
+            ->update([
+                'status' => RecordingWebhookDelivery::STATUS_FAILED,
+                'last_error' => \Illuminate\Support\Str::limit($exception->getMessage(), 500),
+            ]);
+    }
+}

--- a/app/Models/RecordingWebhookDelivery.php
+++ b/app/Models/RecordingWebhookDelivery.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class RecordingWebhookDelivery extends Model
+{
+    use HasFactory, \App\Models\Traits\TraitUuid;
+
+    const STATUS_PENDING = 'pending';
+    const STATUS_SENT = 'sent';
+    const STATUS_FAILED = 'failed';
+    const STATUS_SKIPPED = 'skipped';
+
+    protected $table = "recording_webhook_deliveries";
+
+    protected $primaryKey = 'uuid';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'domain_uuid',
+        'xml_cdr_uuid',
+        'record_name',
+        'url',
+        'status',
+        'attempts',
+        'last_error',
+        'sent_at',
+    ];
+
+    protected $casts = [
+        'sent_at' => 'datetime',
+    ];
+
+    public function cdr()
+    {
+        return $this->belongsTo(CDR::class, 'xml_cdr_uuid', 'xml_cdr_uuid');
+    }
+
+    public function domain()
+    {
+        return $this->belongsTo(Domain::class, 'domain_uuid', 'domain_uuid');
+    }
+}

--- a/app/Services/RecordingWebhookConfigService.php
+++ b/app/Services/RecordingWebhookConfigService.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\DefaultSettings;
+use App\Models\DomainSettings;
+
+class RecordingWebhookConfigService
+{
+    const CATEGORY = 'recording_webhook';
+
+    protected array $subcategories = [
+        'enabled',
+        'url',
+        'secret',
+        'url_ttl',
+        'directions',
+    ];
+
+    /**
+     * Effective settings for a domain: per-key domain override on top of defaults.
+     * Returns null unless enabled with a usable url + secret.
+     */
+    public function getSettingsForDomain(?string $domainUuid): ?array
+    {
+        $settings = $this->getDefaultSettings();
+
+        if ($domainUuid) {
+            $settings = array_merge($settings, $this->getDomainSettings($domainUuid));
+        }
+
+        return $this->normalize($settings);
+    }
+
+    /**
+     * Map of domain_uuid => effective settings for every domain that has the
+     * webhook explicitly enabled at domain level.
+     */
+    public function getEnabledDomainConfigs(): array
+    {
+        $defaults = $this->getDefaultSettings();
+
+        $rows = DomainSettings::query()
+            ->where('domain_setting_category', self::CATEGORY)
+            ->whereIn('domain_setting_subcategory', $this->subcategories)
+            ->where('domain_setting_enabled', true)
+            ->get([
+                'domain_uuid',
+                'domain_setting_subcategory',
+                'domain_setting_value',
+            ]);
+
+        $configs = [];
+
+        foreach ($rows->groupBy('domain_uuid') as $domainUuid => $groupedRows) {
+            $flat = $defaults;
+
+            foreach ($groupedRows as $row) {
+                if ($row->domain_setting_value !== null && $row->domain_setting_value !== '') {
+                    $flat[$row->domain_setting_subcategory] = $row->domain_setting_value;
+                }
+            }
+
+            if ($normalized = $this->normalize($flat)) {
+                $configs[$domainUuid] = $normalized;
+            }
+        }
+
+        return $configs;
+    }
+
+    protected function normalize(array $settings): ?array
+    {
+        $enabled = filter_var($settings['enabled'] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $url = trim($settings['url'] ?? '');
+        $secret = trim($settings['secret'] ?? '');
+
+        if (!$enabled || $url === '' || $secret === '') {
+            return null;
+        }
+
+        $directions = array_values(array_filter(array_map(
+            'trim',
+            explode(',', strtolower($settings['directions'] ?? 'inbound,outbound,local'))
+        )));
+
+        return [
+            'url' => $url,
+            'secret' => $secret,
+            'url_ttl' => max(60, (int) ($settings['url_ttl'] ?? 3600)),
+            'directions' => $directions ?: ['inbound', 'outbound', 'local'],
+        ];
+    }
+
+    protected function getDomainSettings(string $domainUuid): array
+    {
+        return DomainSettings::query()
+            ->where('domain_uuid', $domainUuid)
+            ->where('domain_setting_category', self::CATEGORY)
+            ->whereIn('domain_setting_subcategory', $this->subcategories)
+            ->where('domain_setting_enabled', true)
+            ->pluck('domain_setting_value', 'domain_setting_subcategory')
+            ->filter(fn ($value) => $value !== null && $value !== '')
+            ->toArray();
+    }
+
+    protected function getDefaultSettings(): array
+    {
+        return DefaultSettings::query()
+            ->where('default_setting_category', self::CATEGORY)
+            ->whereIn('default_setting_subcategory', $this->subcategories)
+            ->where('default_setting_enabled', true)
+            ->pluck('default_setting_value', 'default_setting_subcategory')
+            ->filter(fn ($value) => $value !== null && $value !== '')
+            ->toArray();
+    }
+}

--- a/database/migrations/2026_07_02_100000_create_recording_webhook_deliveries.php
+++ b/database/migrations/2026_07_02_100000_create_recording_webhook_deliveries.php
@@ -1,0 +1,117 @@
+<?php
+
+use Illuminate\Support\Str;
+use App\Models\DefaultSettings;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('recording_webhook_deliveries')) {
+            Schema::create('recording_webhook_deliveries', function (Blueprint $table) {
+                $table->uuid('uuid')->primary();
+                $table->uuid('domain_uuid')->index();
+                $table->uuid('xml_cdr_uuid');
+                $table->string('record_name', 255);
+                $table->text('url');
+                $table->string('status', 20)->default('pending');
+                $table->integer('attempts')->default(0);
+                $table->text('last_error')->nullable();
+                $table->timestamp('sent_at')->nullable();
+                $table->timestamps();
+
+                // One delivery per recording file per domain — also the atomic
+                // claim that stops both cluster nodes dispatching the same webhook
+                $table->unique(['domain_uuid', 'record_name']);
+            });
+        }
+
+        $this->seedDefaultSettings();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('recording_webhook_deliveries');
+
+        DefaultSettings::where('default_setting_category', 'recording_webhook')->delete();
+        DefaultSettings::where('default_setting_category', 'scheduled_jobs')
+            ->where('default_setting_subcategory', 'recording_webhooks')
+            ->delete();
+    }
+
+    private function seedDefaultSettings(): void
+    {
+        $settings = [
+            [
+                'default_setting_category'      => 'scheduled_jobs',
+                'default_setting_subcategory'   => 'recording_webhooks',
+                'default_setting_name'          => 'boolean',
+                'default_setting_value'         => 'true',
+                'default_setting_enabled'       => true,
+                'default_setting_description'   => 'Dispatch call recording webhooks for enabled domains every minute.',
+            ],
+            [
+                'default_setting_category'      => 'recording_webhook',
+                'default_setting_subcategory'   => 'enabled',
+                'default_setting_name'          => 'boolean',
+                'default_setting_value'         => 'false',
+                'default_setting_enabled'       => true,
+                'default_setting_description'   => 'Send a webhook when a call recording becomes available. Enable per domain in Domain Settings.',
+            ],
+            [
+                'default_setting_category'      => 'recording_webhook',
+                'default_setting_subcategory'   => 'url',
+                'default_setting_name'          => 'text',
+                'default_setting_value'         => '',
+                'default_setting_enabled'       => true,
+                'default_setting_description'   => 'Destination URL that receives the recording webhook POST.',
+            ],
+            [
+                'default_setting_category'      => 'recording_webhook',
+                'default_setting_subcategory'   => 'secret',
+                'default_setting_name'          => 'text',
+                'default_setting_value'         => '',
+                'default_setting_enabled'       => true,
+                'default_setting_description'   => 'Shared secret used to HMAC-SHA256 sign the webhook payload (X-Voxra-Signature).',
+            ],
+            [
+                'default_setting_category'      => 'recording_webhook',
+                'default_setting_subcategory'   => 'url_ttl',
+                'default_setting_name'          => 'numeric',
+                'default_setting_value'         => '3600',
+                'default_setting_enabled'       => true,
+                'default_setting_description'   => 'How long (seconds) the recording links in the payload stay valid.',
+            ],
+            [
+                'default_setting_category'      => 'recording_webhook',
+                'default_setting_subcategory'   => 'directions',
+                'default_setting_name'          => 'text',
+                'default_setting_value'         => 'inbound,outbound,local',
+                'default_setting_enabled'       => true,
+                'default_setting_description'   => 'Comma-separated call directions that trigger the webhook.',
+            ],
+        ];
+
+        foreach ($settings as $setting) {
+            $exists = DefaultSettings::where('default_setting_category', $setting['default_setting_category'])
+                ->where('default_setting_subcategory', $setting['default_setting_subcategory'])
+                ->where('default_setting_name', $setting['default_setting_name'])
+                ->exists();
+
+            if (!$exists) {
+                DefaultSettings::create(array_merge($setting, [
+                    'default_setting_uuid' => (string) Str::uuid(),
+                ]));
+            }
+        }
+    }
+};


### PR DESCRIPTION
## What

When a call recording becomes available, POST a signed JSON payload (call metadata + time-limited recording URLs) to a per-domain configurable URL. First consumer: crm.iqmobile.biz, which transcribes recordings via Vercel AI Gateway (grok-stt) and attaches transcripts to CRM contacts.

## How

- **Settings** via `default_settings`/`domain_settings` category `recording_webhook`: `enabled`, `url`, `secret`, `url_ttl` (default 3600s), `directions` (default all). Seeded by the migration, disabled by default — enable per domain in Domain Settings. No new UI.
- **`webhooks:dispatch-recordings`** artisan command runs every minute (gated by `scheduled_jobs`/`recording_webhooks` default setting, seeded on). Scans recorded CDRs in enabled domains over a 24h lookback, dedupes multi-leg recordings (ring-group legs share one file — one webhook per file, primary leg = longest billsec), and claims work atomically via `insertOrIgnore` + `unique(domain_uuid, record_name)` so both cluster nodes can run it without double-sending.
- **`SendRecordingWebhook`** job (Horizon): signs the body with HMAC-SHA256 (`X-Voxra-Signature: t=<ts>,v0=<hex>`, signed string `<ts>.<body>` — same scheme as the ElevenLabs inbound webhook), 5 tries with 1m/5m/15m/30m backoff, delivery state tracked in the new `recording_webhook_deliveries` table (`--retry-failed` flag re-queues failures).
- **Recording URLs** come from the existing `CallRecordingUrlService`, so local WAVs (signed routes) and S3-archived MP3s (presigned URLs) both work transparently; links expire after `url_ttl`.

## Testing

- All files lint clean (php -l, PHP 8.4).
- Receiver side (iqcrm 8822661) verified end-to-end locally against a real PBX recording: signature verification (valid + tampered + stale), Communication upsert, grok-stt transcription, summary.
- Payload contract consumed by `src/app/api/webhooks/voxra/recording/route.ts` in iqcrm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DK59AfYj16fpWXzwHkQBx