### PR TITLE
Dispatch recording webhooks only from the node that holds the recording

### DIFF
--- a/app/Console/Commands/DispatchRecordingWebhooks.php
+++ b/app/Console/Commands/DispatchRecordingWebhooks.php
@@ -60,6 +60,7 @@ class DispatchRecordingWebhooks extends Command
                 ->get([
                     'xml_cdr_uuid',
                     'domain_uuid',
+                    'record_path',
                     'record_name',
                     'direction',
                     'billsec',
@@ -73,6 +74,14 @@ class DispatchRecordingWebhooks extends Command
             });
 
             foreach ($primaryLegs as $cdr) {
+                // Locally-stored recordings can only be served by the node that
+                // holds the file: the webhook URL is signed with this node's
+                // APP_KEY and points at this node's APP_URL. Leave the CDR
+                // unclaimed so the node that recorded the call dispatches it.
+                if (!$this->recordingIsServableHere($cdr)) {
+                    continue;
+                }
+
                 // insertOrIgnore + unique(domain_uuid, record_name) is the atomic
                 // claim: whichever cluster node inserts the row sends the webhook
                 $inserted = RecordingWebhookDelivery::insertOrIgnore([
@@ -102,6 +111,22 @@ class DispatchRecordingWebhooks extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Whether this node can serve the CDR's recording. S3-backed recordings
+     * are reachable from any node (presigned object URLs); local recordings
+     * only from the node whose disk holds the file.
+     */
+    private function recordingIsServableHere($cdr): bool
+    {
+        if ($cdr->record_path === 'S3') {
+            return true;
+        }
+
+        $dir = rtrim($cdr->record_path ?: '', '/');
+
+        return $dir !== '' && is_file($dir . '/' . $cdr->record_name);
     }
 
     private function retryFailed(array $domainUuids): void

--- a/app/Jobs/SendRecordingWebhook.php
+++ b/app/Jobs/SendRecordingWebhook.php
@@ -64,6 +64,20 @@ class SendRecordingWebhook implements ShouldQueue
             return;
         }
 
+        // A locally-stored recording can only be served by the node that holds
+        // the file — the signed URL uses this node's APP_URL/APP_KEY. Fail
+        // loudly rather than deliver a URL that will 404 on fetch.
+        if ($cdr->record_path !== 'S3') {
+            $dir = rtrim($cdr->record_path ?: '', '/');
+            if ($dir === '' || !is_file($dir . '/' . $cdr->record_name)) {
+                $delivery->update([
+                    'status' => RecordingWebhookDelivery::STATUS_FAILED,
+                    'last_error' => 'Recording file not present on this node (' . gethostname() . ')',
+                ]);
+                return;
+            }
+        }
+
         $delivery->increment('attempts');
 
         $urls = $urlService->urlsForCdr($cdr->xml_cdr_uuid, $config['url_ttl']);


### PR DESCRIPTION
## Problem

In the two-node Voxra cluster (lon1 primary, eu1 secondary) sharing one Postgres database, `webhooks:dispatch-recordings` runs on both nodes every minute and races on the shared `recording_webhook_deliveries` claim table. When eu1 wins the claim for a call recorded on lon1:

- the signed stream URL is generated with **eu1's** `APP_URL`/`APP_KEY`
- the recording file only exists on **lon1's** disk

so the CRM's fetch can never succeed. Over the last 7 days **14 of 93** recording webhooks were emitted this way and their transcriptions were abandoned (`recording fetch failed`, CRM `voxra-recording-retry` cron gave up after URL expiry).

(eu1's `APP_URL` was also set to a raw IP, which made the failure loud — but even with a correct `APP_URL`, eu1 cannot serve a file it doesn't have.)

## Fix

- **DispatchRecordingWebhooks**: before claiming, skip CDRs whose recording is neither `record_path == 'S3'` nor a file on this node's disk. The CDR stays unclaimed, so the node that actually holds the recording claims and dispatches it on its next scheduler tick.
- **SendRecordingWebhook**: if the local file is missing at send time (e.g. `--retry-failed` run on the wrong node), mark the delivery failed with an explicit error naming the host, instead of emitting a URL that will 404.

S3-backed recordings are unaffected — presigned object URLs work from any node.

## Testing

- `php -l` on both files.
- Verified on live data: the 14 failed deliveries' files exist on lon1 and not on eu1; re-dispatch from lon1 succeeds (see iqcrm Communications — transcriptions now complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gB8i7pnC3RsaQkQDnE9pW