### PR TITLE
Transcode oversized WAV recordings before webhook delivery

### DIFF
--- a/app/Jobs/SendRecordingWebhook.php
+++ b/app/Jobs/SendRecordingWebhook.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use App\Services\CallRecordingUrlService;
 use Illuminate\Foundation\Bus\Dispatchable;
 use App\Services\RecordingWebhookConfigService;
+use Symfony\Component\Process\Process;
 
 class SendRecordingWebhook implements ShouldQueue
 {
@@ -76,6 +77,8 @@ class SendRecordingWebhook implements ShouldQueue
                 ]);
                 return;
             }
+
+            $this->transcodeOversizedWav($cdr, $dir);
         }
 
         $delivery->increment('attempts');
@@ -141,6 +144,64 @@ class SendRecordingWebhook implements ShouldQueue
             'sent_at' => now(),
             'last_error' => null,
         ]);
+    }
+
+    /**
+     * WebRTC/verto legs are recorded at their native format (48kHz stereo PCM,
+     * ~11.5MB/min) instead of the usual 16kHz mono, producing WAVs of 100MB+
+     * that downstream consumers cannot ingest (the CRM transcription pipeline
+     * rejects payloads over 80MB). Before delivering the webhook, convert any
+     * oversized WAV to 16kHz mono MP3 (~130KB/min) and point the CDR at the
+     * new file so the signed URLs — and any later playback — use it.
+     */
+    private const TRANSCODE_THRESHOLD_BYTES = 25 * 1024 * 1024;
+
+    private function transcodeOversizedWav(CDR $cdr, string $dir): void
+    {
+        $wavPath = $dir . '/' . $cdr->record_name;
+
+        if (strtolower(pathinfo($wavPath, PATHINFO_EXTENSION)) !== 'wav') {
+            return;
+        }
+
+        $size = filesize($wavPath);
+        if ($size === false || $size <= self::TRANSCODE_THRESHOLD_BYTES) {
+            return;
+        }
+
+        $mp3Name = preg_replace('/\.wav$/i', '.mp3', $cdr->record_name);
+        $mp3Path = $dir . '/' . $mp3Name;
+
+        $process = new Process([
+            'ffmpeg',
+            '-nostdin',
+            '-y',
+            '-i', $wavPath,
+            '-ac', '1',
+            '-ar', '16000',
+            '-b:a', '32k',
+            $mp3Path,
+        ]);
+        $process->setTimeout(1800);
+        $process->run();
+
+        if (!$process->isSuccessful() || !is_file($mp3Path) || filesize($mp3Path) === 0) {
+            @unlink($mp3Path);
+            logger()->warning('Recording webhook: ffmpeg transcode failed for ' . $wavPath
+                . ' — delivering original WAV. ' . Str::limit($process->getErrorOutput(), 500));
+            return;
+        }
+
+        CDR::where('xml_cdr_uuid', $cdr->xml_cdr_uuid)->update(['record_name' => $mp3Name]);
+        $cdr->record_name = $mp3Name;
+        @unlink($wavPath);
+
+        logger()->info(sprintf(
+            'Recording webhook: transcoded oversized WAV %s (%.1fMB -> %.1fMB)',
+            $cdr->xml_cdr_uuid,
+            $size / 1048576,
+            filesize($mp3Path) / 1048576
+        ));
     }
 
     public function failed(\Throwable $exception): void


### PR DESCRIPTION
## Problem

WebRTC/verto call legs are recorded at their native format — 48kHz stereo PCM ≈ 11.5MB/min — instead of the usual 16kHz mono (~2MB/min). An 11m27s call from ext 817 produced a **131MB WAV** (cdr `d3a7baea`, confirmed via ffprobe: `pcm_s16le, 48000Hz, 2ch`) that the CRM transcription pipeline can never ingest: it exceeds the AI Gateway request limit and the CRM now fails fast on payloads over 80MB. The recording ended up parked as `transcriptionStatus: abandoned`. See ystwythv/iqcrm#73.

## Fix

In `SendRecordingWebhook`, after confirming the local file exists and before building signed URLs:

- if the recording is a local WAV **over 25MB**, transcode it to 16kHz mono 32kbps MP3 (same ffmpeg conversion the S3 uploader `UploadCallRecordingsToS3Storage::convertToMp3IfNeeded` already performs, plus an explicit `-ar 16000`) — 131MB → roughly 3MB
- update `v_xml_cdr.record_name` to the `.mp3` so the signed URLs (re-read from the DB by `CallRecordingUrlService`) and any later playback use the new file, then delete the WAV
- on ffmpeg failure: log a warning and deliver the original WAV rather than failing the delivery

Normal 16kHz mono recordings stay untouched (a 25MB WAV at that rate is ~13 minutes; oversized verto legs hit the threshold at ~2 minutes).

## Notes

- ffmpeg is already installed on both nodes and already a dependency of the S3 upload path.
- Only the node holding the file dispatches deliveries since #88, so the transcode always runs where the WAV lives.
- Root cause (verto legs recording at 48kHz stereo) could additionally be fixed at source with `record_sample_rate=16000` in the `user_record` dialplan, but that touches shared FusionPBX dialplan config for all recordings; this webhook-time transcode is sufficient for the pipeline and safer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TatQ7E7sCxD8Y7cvT4RQo3