### PR TITLE
fix: migrations referenced default_settings instead of v_default_settings

### DIFF
--- a/database/migrations/2026_07_20_000002_create_call_rating_tables.php
+++ b/database/migrations/2026_07_20_000002_create_call_rating_tables.php
@@ -78,7 +78,7 @@ return new class extends Migration
         Schema::dropIfExists('v_call_rates');
         Schema::dropIfExists('v_call_tariffs');
 
-        DB::table('default_settings')
+        DB::table('v_default_settings')
             ->where('default_setting_category', 'scheduled_jobs')
             ->where('default_setting_subcategory', 'cdr_rating')
             ->delete();
@@ -86,13 +86,13 @@ return new class extends Migration
 
     private function seedDefaultSettings(): void
     {
-        $exists = DB::table('default_settings')
+        $exists = DB::table('v_default_settings')
             ->where('default_setting_category', 'scheduled_jobs')
             ->where('default_setting_subcategory', 'cdr_rating')
             ->exists();
 
         if (! $exists) {
-            DB::table('default_settings')->insert([
+            DB::table('v_default_settings')->insert([
                 'default_setting_uuid' => (string) \Illuminate\Support\Str::uuid(),
                 'default_setting_category' => 'scheduled_jobs',
                 'default_setting_subcategory' => 'cdr_rating',

--- a/database/migrations/2026_07_20_000003_create_api_webhooks_tables.php
+++ b/database/migrations/2026_07_20_000003_create_api_webhooks_tables.php
@@ -63,7 +63,7 @@ return new class extends Migration
 
         DB::table('v_group_permissions')->where('permission_name', 'api_webhook_manage')->delete();
         DB::table('v_permissions')->where('permission_name', 'api_webhook_manage')->delete();
-        DB::table('default_settings')
+        DB::table('v_default_settings')
             ->where('default_setting_category', 'scheduled_jobs')
             ->where('default_setting_subcategory', 'cdr_webhooks')
             ->delete();
@@ -111,13 +111,13 @@ return new class extends Migration
 
     private function seedDefaultSettings(): void
     {
-        $exists = DB::table('default_settings')
+        $exists = DB::table('v_default_settings')
             ->where('default_setting_category', 'scheduled_jobs')
             ->where('default_setting_subcategory', 'cdr_webhooks')
             ->exists();
 
         if (! $exists) {
-            DB::table('default_settings')->insert([
+            DB::table('v_default_settings')->insert([
                 'default_setting_uuid' => (string) Str::uuid(),
                 'default_setting_category' => 'scheduled_jobs',
                 'default_setting_subcategory' => 'cdr_webhooks',

--- a/docs/cdr-rating.md
+++ b/docs/cdr-rating.md
@@ -49,7 +49,7 @@ The scheduler entry (`cdr:rate` every 5 minutes) is gated by the
 Enable it after loading the first tariff:
 
 ```sql
-UPDATE default_settings SET default_setting_value = 'true'
+UPDATE v_default_settings SET default_setting_value = 'true'
 WHERE default_setting_category = 'scheduled_jobs'
   AND default_setting_subcategory = 'cdr_rating';
 ```


### PR DESCRIPTION
Deploy of PR #92 left three migrations pending: the scheduler-gate seeding in the rating and webhook migrations referenced `default_settings`, but the FusionPBX table is `v_default_settings` (as the `DefaultSettings` model maps). Fixes both migrations' seed + down() paths and the SQL snippet in docs/cdr-rating.md.

Verified failure on voxra-pbx-lon1 (`php artisan migrate --force` → SQLSTATE 42P01); the permission-grant and menu migrations are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RURiTx73cm8RoB1jLUbaDu