### PR TITLE
fix: API throttle responses rendered as 500 instead of 429

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -12,6 +12,7 @@ use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
@@ -144,7 +145,27 @@ class Handler extends ExceptionHandler
             return response()->json($payload->toArray(), $e->status);
         });
 
-        // 5) Catch-all MUST be last
+        // 5) Framework HTTP exceptions keep their real status — without this
+        // the catch-all turned throttle 429s (and any other HttpException)
+        // into opaque 500s
+        $this->renderable(function (HttpExceptionInterface $e, Request $request) {
+            if (! $request->is('api/v1/*')) return null;
+
+            $status = $e->getStatusCode();
+
+            $payload = ErrorResponseData::from([
+                'error' => ErrorData::from([
+                    'type'    => $status === 429 ? 'rate_limit_error' : 'api_error',
+                    'message' => $e->getMessage() !== '' ? $e->getMessage() : 'HTTP ' . $status,
+                    'doc_url' => 'https://www.fspbx.com/docs/api/v1/errors/',
+                ]),
+            ]);
+
+            // getHeaders() carries Retry-After / X-RateLimit-* on throttle
+            return response()->json($payload->toArray(), $status, $e->getHeaders());
+        });
+
+        // 6) Catch-all MUST be last
         $this->renderable(function (Throwable $e, Request $request) {
             if (! $request->is('api/v1/*')) return null;
 

--- a/tests/Integration/Cdr/CdrApiIntegrationTest.php
+++ b/tests/Integration/Cdr/CdrApiIntegrationTest.php
@@ -245,6 +245,30 @@ class CdrApiIntegrationTest extends CdrIntegrationTestCase
         )->assertStatus(401);
     }
 
+    public function test_stats_rate_limit_returns_429_not_500(): void
+    {
+        $domain = $this->makeDomain();
+        $user = $this->makeUser($domain, ['cdr_api_read']);
+        $token = $this->mintToken($user, $domain);
+
+        $url = "/api/v1/domains/{$domain}/cdr/stats/summary?" . $this->isoWindowAroundNow();
+
+        // cdr-stats bucket is 30/min per token; the 31st must be a clean 429
+        // (a Handler catch-all used to turn it into an opaque 500)
+        $status = null;
+        for ($i = 1; $i <= 31; $i++) {
+            $response = $this->get($url, $this->bearer($token));
+            $status = $response->status();
+            if ($status !== 200) {
+                break;
+            }
+        }
+
+        $this->assertSame(429, $status, "expected 429 after exceeding the limit, got {$status} on request {$i}");
+        $response->assertHeader('Retry-After');
+        $this->assertSame('rate_limit_error', $response->json('error.type'));
+    }
+
     public function test_min_mos_filter(): void
     {
         $domain = $this->makeDomain();


### PR DESCRIPTION
Found running the issue #15 smoke checklist: the 429 test never reproduced because the api/v1 catch-all renderable in `app/Exceptions/Handler.php` converts every Throwable — including `ThrottleRequestsException` — into a 500 "Unhandled API exception" (confirmed in laravel.log on lon1).

Adds an `HttpExceptionInterface` renderable ahead of the catch-all so framework HTTP exceptions keep their real status and headers (Retry-After / X-RateLimit-Reset on throttle), with `rate_limit_error` type for 429s. Regression test exceeds the real cdr-stats limiter (31 requests) in the integration suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RURiTx73cm8RoB1jLUbaDu